### PR TITLE
For the locked implementations switch to RWMutex

### DIFF
--- a/locked_ordered.go
+++ b/locked_ordered.go
@@ -8,6 +8,7 @@ import (
 // LockedOrdered is a set implementation that maintains the order of elements and is safe for concurrent use. If the
 // same item is added multiple times, the first insertion determines the order.
 type LockedOrdered[M comparable] struct {
+	*sync.RWMutex
 	*sync.Cond
 	iterating bool
 	idx       map[M]int
@@ -18,10 +19,12 @@ var _ Set[int] = new(LockedOrdered[int])
 
 // NewLockedOrdered returns an empty LockedOrderedSet instance.
 func NewLockedOrdered[M comparable]() *LockedOrdered[M] {
+	mu := &sync.RWMutex{}
 	return &LockedOrdered[M]{
-		idx:    make(map[M]int),
-		values: make([]M, 0),
-		Cond:   sync.NewCond(&sync.Mutex{}),
+		idx:     make(map[M]int),
+		values:  make([]M, 0),
+		RWMutex: mu,
+		Cond:    sync.NewCond(mu),
 	}
 }
 
@@ -35,11 +38,8 @@ func NewLockedOrderedFrom[M comparable](seq iter.Seq[M]) *LockedOrdered[M] {
 }
 
 func (s *LockedOrdered[M]) Contains(m M) bool {
-	s.Cond.L.Lock()
-	if s.iterating {
-		s.Cond.Wait()
-	}
-	defer s.Cond.L.Unlock()
+	s.RWMutex.RLock()
+	defer s.RWMutex.RUnlock()
 	return s.contains(m)
 }
 
@@ -95,16 +95,13 @@ func (s *LockedOrdered[M]) Remove(m M) bool {
 }
 
 func (s *LockedOrdered[M]) Cardinality() int {
-	s.Cond.L.Lock()
-	if s.iterating {
-		s.Cond.Wait()
-	}
-	defer s.Cond.L.Unlock()
+	s.RWMutex.RLock()
+	defer s.RWMutex.RUnlock()
 	return len(s.values)
 }
 
-// Iterator yields all elements in the set in order. It holds a lock for the duration of iteration, so calling other methods will block
-// until iteration is complete.
+// Iterator yields all elements in the set in order. It holds a lock for the duration of iteration. Calling methods other than
+// `Contains` and `Cardinality` will block until the iteration is complete.
 func (s *LockedOrdered[M]) Iterator(yield func(M) bool) {
 	s.Cond.L.Lock()
 	s.iterating = true

--- a/set_test.go
+++ b/set_test.go
@@ -333,14 +333,36 @@ func testSetConcurrency(t *testing.T, set Set[int]) {
 	changes := make(chan int, 100)
 
 	for i := range 20 {
-		started.Add(3)
-		finished.Add(3)
+		started.Add(5)
+		finished.Add(5)
 		go func(base int) {
 			started.Done()
 			started.Wait()
 			for i := range (base + 1) * 100 {
 				set.Add(i)
 			}
+			finished.Done()
+		}(i)
+
+		go func(base int) {
+			started.Done()
+			started.Wait()
+			var x int
+			for range (base + 1) * 100 {
+				x = set.Cardinality()
+			}
+			_ = x
+			finished.Done()
+		}(i)
+
+		go func(base int) {
+			started.Done()
+			started.Wait()
+			var x bool
+			for i := range (base + 1) * 100 {
+				x = set.Contains(i)
+			}
+			_ = x
 			finished.Done()
 		}(i)
 
@@ -355,7 +377,7 @@ func testSetConcurrency(t *testing.T, set Set[int]) {
 
 		go func(base int) {
 			other := New[int]()
-			for i := range (base + 1) * 1000 {
+			for i := range (base + 1) * 100 {
 				other.Add(i)
 			}
 			started.Done()


### PR DESCRIPTION
This allows for reading some values during iteration.

Also exposed the RWMutex so that it can be accessed if needed.