### PR TITLE
Updates / Cleanups

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "go.testFlags": [
-        "-rapid.v"
+        // "-rapid.v"
+        "-test.count","1",
     ]
 }

--- a/README.MD
+++ b/README.MD
@@ -6,6 +6,8 @@
 
 A generics based go set package that supports modern go features.
 
+NOTE: This is currently a WIP
+
 ## Install
 
 Use go get to install this package.
@@ -23,7 +25,7 @@ go get github.com/freeformz/set
   * `New()` -> Map based set;
   * `NewLocked()` -> Map based that uses a lock to be concurrency safe;
   * `NewSync()` -> sync.Map based (concurrency safe);
-  * `NewOrdered()` -> ordred set (uses a map for indexes and a slice for order);
+  * `NewOrdered()` -> ordered set (uses a map for indexes and a slice for order);
   * `NewLockedOrdered()` -> ordered set that is concurrency safe.
 * `set` package functions align with standard lib packages like `slices` and `maps`.
 * Exhaustive unit tests via [rapid](https://github.com/flyingmutant/rapid).
@@ -54,3 +56,8 @@ See the package level [examples](https://pkg.go.dev/github.com/freeformz/set#pkg
 
   ...
 ```
+
+## TODOs
+
+* Ordered rapid tests that test the OrderedSet bits like the normal Set bits are tested.
+* More examples?

--- a/examples_test.go
+++ b/examples_test.go
@@ -13,17 +13,11 @@ func ExampleSet_Iterator() {
 	ints.Add(4)
 	ints.Add(1)
 
-	out := make([]int, 0, ints.Cardinality())
 	for i := range ints.Iterator {
-		out = append(out, i)
-	}
-
-	// sort the values for consistent output
-	slices.Sort(out)
-	for _, i := range out {
 		fmt.Println(i)
 	}
-	// Output:
+
+	// Unsorted output:
 	// 1
 	// 2
 	// 3
@@ -100,11 +94,10 @@ func ExampleElements() {
 
 	// []T is returned
 	elements := Elements(ints)
-	slices.Sort(elements) // sorted for stable outputs
 	for _, i := range elements {
 		fmt.Println(i)
 	}
-	// Output:
+	// Unsorted output:
 	// 2
 	// 3
 	// 5
@@ -207,15 +200,10 @@ func ExampleSymmetricDifference() {
 	b.Add(2)
 
 	c := SymmetricDifference(a, b)
-	out := make([]int, 0, c.Cardinality())
 	for i := range c.Iterator {
-		out = append(out, i)
-	}
-	slices.Sort(out)
-	for _, i := range out {
 		fmt.Println(i)
 	}
-	// Output:
+	// Unordered output:
 	// 2
 	// 5
 }
@@ -329,4 +317,102 @@ func ExampleDisjoint() {
 	// Output:
 	// a and b are disjoint
 	// a and b are not disjoint now
+}
+
+func ExampleEqualOrdered() {
+	a := NewOrdered[int]()
+	a.Add(5)
+	a.Add(3)
+	a.Add(1)
+
+	b := NewOrdered[int]()
+	b.Add(5)
+	b.Add(3)
+	b.Add(1)
+
+	if EqualOrdered(a, b) {
+		fmt.Println("a and b are equal")
+	}
+
+	b.Add(2)
+	if !EqualOrdered(a, b) {
+		fmt.Println("a and b are not equal now")
+	}
+	// Output:
+	// a and b are equal
+	// a and b are not equal now
+}
+
+func ExampleMin() {
+	ints := New[int]()
+	ints.Add(3)
+	ints.Add(2)
+	ints.Add(5)
+
+	min := Min(ints)
+	fmt.Println(min)
+	// Output: 2
+}
+
+func ExampleMax() {
+	ints := New[int]()
+	ints.Add(3)
+	ints.Add(5)
+	ints.Add(2)
+
+	max := Max(ints)
+	fmt.Println(max)
+	// Output: 5
+}
+
+func ExampleIsSorted() {
+	ints := NewOrdered[int]()
+	ints.Add(2)
+	ints.Add(3)
+	ints.Add(5)
+
+	if IsSorted(ints) {
+		fmt.Println("ints is sorted")
+	}
+
+	ints.Add(4)
+	if !IsSorted(ints) {
+		fmt.Println("ints is not sorted now")
+	}
+
+	ints.Sort()
+	if IsSorted(ints) {
+		fmt.Println("ints is sorted")
+	}
+	// Output:
+	// ints is sorted
+	// ints is not sorted now
+	// ints is sorted
+}
+
+func ExampleReverse() {
+	ints := NewOrdered[int]()
+	ints.Add(2)
+	ints.Add(3)
+	ints.Add(5)
+
+	reversed := Reverse(ints)
+	for i := range reversed.Iterator {
+		fmt.Println(i)
+	}
+	// Output:
+	// 5
+	// 3
+	// 2
+}
+
+func ExampleSet_String() {
+	// using an ordered set for consistent output
+	ints := NewOrdered[int]()
+	ints.Add(5)
+	ints.Add(3)
+	ints.Add(2)
+
+	fmt.Println(ints)
+	// Output: OrderedSet[int]([5 3 2])
 }

--- a/locked.go
+++ b/locked.go
@@ -5,29 +5,27 @@ import (
 	"sync"
 )
 
-// LockedMap is a set implementation using a map and a mutex (via the sync.Cond). Instances of this type are safe to be used
-// concurrently. Iteration holds the lock for the duration of the iteration.
-type LockedMap[M comparable] struct {
+type lockedMap[M comparable] struct {
 	*sync.RWMutex
 	*sync.Cond
 	iterating bool
-	m         map[M]struct{}
+	set       Set[M]
 }
 
-var _ Set[int] = new(LockedMap[int])
+var _ Set[int] = new(lockedMap[int])
 
-// NewLocked returns an empty LockedMapSet instance.
-func NewLocked[M comparable]() *LockedMap[M] {
+// NewLocked returns an empty Set[M] that is safe for concurrent use.
+func NewLocked[M comparable]() Set[M] {
 	mu := &sync.RWMutex{}
-	return &LockedMap[M]{
-		m:       make(map[M]struct{}),
+	return &lockedMap[M]{
+		set:     New[M](),
 		RWMutex: mu,
 		Cond:    sync.NewCond(mu),
 	}
 }
 
-// NewLockedFrom returns a new LockedMapSet instance filled with the values from the sequence.
-func NewLockedFrom[M comparable](seq iter.Seq[M]) *LockedMap[M] {
+// NewLockedFrom returns a new Set[M] filled with the values from the sequence.
+func NewLockedFrom[M comparable](seq iter.Seq[M]) Set[M] {
 	s := NewLocked[M]()
 	for x := range seq {
 		s.Add(x)
@@ -35,70 +33,77 @@ func NewLockedFrom[M comparable](seq iter.Seq[M]) *LockedMap[M] {
 	return s
 }
 
-func (s *LockedMap[M]) Contains(m M) bool {
+type locker interface {
+	Lock()
+	Unlock()
+	RLock()
+	RUnlock()
+	Wait()
+	Broadcast()
+}
+
+// NewLockedWith returns a Set[M]. If set is already a locked set, then it is just returned as is. If set isn't a locked set
+// then the returned set is wrapped so that it is safe for concurrent use.
+func NewLockedWith[M comparable](set Set[M]) Set[M] {
+	if _, lok := set.(locker); lok {
+		return set
+	}
+	mu := &sync.RWMutex{}
+	return &lockedMap[M]{
+		set:     set,
+		RWMutex: mu,
+		Cond:    sync.NewCond(mu),
+	}
+}
+
+func (s *lockedMap[M]) Contains(m M) bool {
 	s.RWMutex.RLock()
 	defer s.RWMutex.RUnlock()
-	return s.contains(m)
+	return s.set.Contains(m)
 }
 
-func (s *LockedMap[M]) Clear() int {
+func (s *lockedMap[M]) Clear() int {
+	s.Cond.L.Lock()
+	if s.iterating {
+		s.Cond.Wait()
+	}
+	defer s.Cond.L.Unlock()
+	return s.set.Clear()
+}
+
+func (s *lockedMap[M]) Add(m M) bool {
 	s.Cond.L.Lock()
 	if s.iterating {
 		s.Cond.Wait()
 	}
 	defer s.Cond.L.Unlock()
 
-	n := len(s.m)
-	for k := range s.m {
-		delete(s.m, k)
-	}
-	return n
+	return s.set.Add(m)
 }
 
-func (s *LockedMap[M]) contains(m M) bool {
-	_, ok := s.m[m]
-	return ok
-}
-
-func (s *LockedMap[M]) Add(m M) bool {
+func (s *lockedMap[M]) Remove(m M) bool {
 	s.Cond.L.Lock()
 	if s.iterating {
 		s.Cond.Wait()
 	}
 	defer s.Cond.L.Unlock()
 
-	if s.contains(m) {
-		return false
-	}
-	s.m[m] = struct{}{}
-
-	return true
+	return s.set.Remove(m)
 }
 
-func (s *LockedMap[M]) Remove(m M) bool {
-	s.Cond.L.Lock()
-	if s.iterating {
-		s.Cond.Wait()
+func (s *lockedMap[M]) Cardinality() int {
+	if s == nil {
+		return 0
 	}
-	defer s.Cond.L.Unlock()
-
-	if !s.contains(m) {
-		return false
-	}
-	delete(s.m, m)
-	return true
-}
-
-func (s *LockedMap[M]) Cardinality() int {
 	s.RWMutex.RLock()
 	defer s.RWMutex.RUnlock()
 
-	return len(s.m)
+	return s.set.Cardinality()
 }
 
 // Iterator yields all elements in the set. It holds a lock for the duration of iteration. Calling methods other than
 // `Contains` and `Cardinality` will block until the iteration is complete.
-func (s *LockedMap[M]) Iterator(yield func(M) bool) {
+func (s *lockedMap[M]) Iterator(yield func(M) bool) {
 	s.Cond.L.Lock()
 	s.iterating = true
 	defer func() {
@@ -106,13 +111,20 @@ func (s *LockedMap[M]) Iterator(yield func(M) bool) {
 		s.Cond.Broadcast()
 		s.Cond.L.Unlock()
 	}()
-	for k := range s.m {
-		if !yield(k) {
-			return
-		}
-	}
+
+	s.set.Iterator(yield)
 }
 
-func (s *LockedMap[M]) Clone() Set[M] {
+func (s *lockedMap[M]) Clone() Set[M] {
 	return NewLockedFrom(s.Iterator)
+}
+
+func (s *lockedMap[M]) NewEmpty() Set[M] {
+	return NewLocked[M]()
+}
+
+func (s *lockedMap[M]) String() string {
+	s.RLock()
+	defer s.RUnlock()
+	return "Locked" + s.set.String()
 }

--- a/locked_ordered.go
+++ b/locked_ordered.go
@@ -1,35 +1,33 @@
 package set
 
 import (
+	"cmp"
 	"iter"
 	"sync"
 )
 
-// LockedOrdered is a set implementation that maintains the order of elements and is safe for concurrent use. If the
-// same item is added multiple times, the first insertion determines the order.
-type LockedOrdered[M comparable] struct {
+type lockedOrdered[M cmp.Ordered] struct {
 	*sync.RWMutex
 	*sync.Cond
 	iterating bool
-	idx       map[M]int
-	values    []M
+	set       OrderedSet[M]
 }
 
-var _ Set[int] = new(LockedOrdered[int])
+var _ Set[int] = new(lockedOrdered[int])
 
-// NewLockedOrdered returns an empty LockedOrderedSet instance.
-func NewLockedOrdered[M comparable]() *LockedOrdered[M] {
+// NewLockedOrdered returns an empty OrderedSet[M] instance that is safe for concurrent use.
+func NewLockedOrdered[M cmp.Ordered]() OrderedSet[M] {
 	mu := &sync.RWMutex{}
-	return &LockedOrdered[M]{
-		idx:     make(map[M]int),
-		values:  make([]M, 0),
+	return &lockedOrdered[M]{
+		set:     NewOrdered[M](),
 		RWMutex: mu,
 		Cond:    sync.NewCond(mu),
 	}
 }
 
-// NewLockedOrderedFrom returns a new LockedOrderedSet instance filled with the values from the sequence.
-func NewLockedOrderedFrom[M comparable](seq iter.Seq[M]) *LockedOrdered[M] {
+// NewLockedOrderedFrom returns a new OrderedSet[M] instance filled with the values from the sequence. The set is safe
+// for concurrent use.
+func NewLockedOrderedFrom[M cmp.Ordered](seq iter.Seq[M]) OrderedSet[M] {
 	s := NewLockedOrdered[M]()
 	for x := range seq {
 		s.Add(x)
@@ -37,87 +35,140 @@ func NewLockedOrderedFrom[M comparable](seq iter.Seq[M]) *LockedOrdered[M] {
 	return s
 }
 
-func (s *LockedOrdered[M]) Contains(m M) bool {
-	s.RWMutex.RLock()
-	defer s.RWMutex.RUnlock()
-	return s.contains(m)
+// NewLockedOrderedWith returns an OrderedSet[M]. If set is already a locked set, then it is just returned as is. If set isn't a locked set
+// then the returned set is wrapped so that it is safe for concurrent use.
+func NewLockedOrderedWith[M cmp.Ordered](set OrderedSet[M]) OrderedSet[M] {
+	if _, lok := set.(locker); lok {
+		return set
+	}
+	mu := &sync.RWMutex{}
+	return &lockedOrdered[M]{
+		set:     set,
+		RWMutex: mu,
+		Cond:    sync.NewCond(mu),
+	}
 }
 
-func (s *LockedOrdered[M]) Clear() int {
-	s.Cond.L.Lock()
+func (s *lockedOrdered[M]) Contains(m M) bool {
+	s.RLock()
+	defer s.RUnlock()
+	return s.set.Contains(m)
+}
+
+func (s *lockedOrdered[M]) Clear() int {
+	s.L.Lock()
 	if s.iterating {
-		s.Cond.Wait()
+		s.Wait()
 	}
-	defer s.Cond.L.Unlock()
-	n := len(s.values)
-	for k := range s.idx {
-		delete(s.idx, k)
-	}
-	s.values = s.values[:0]
-	return n
+	defer s.L.Unlock()
+	return s.set.Clear()
 }
 
-func (s *LockedOrdered[M]) contains(m M) bool {
-	_, ok := s.idx[m]
-	return ok
-}
-
-func (s *LockedOrdered[M]) Add(m M) bool {
-	s.Cond.L.Lock()
+func (s *lockedOrdered[M]) Add(m M) bool {
+	s.L.Lock()
 	if s.iterating {
-		s.Cond.Wait()
+		s.Wait()
 	}
-	defer s.Cond.L.Unlock()
-	if s.contains(m) {
-		return false
-	}
-	s.values = append(s.values, m)
-	s.idx[m] = len(s.values) - 1
-	return true
+	defer s.L.Unlock()
+	return s.set.Add(m)
 }
 
-func (s *LockedOrdered[M]) Remove(m M) bool {
-	s.Cond.L.Lock()
+func (s *lockedOrdered[M]) Remove(m M) bool {
+	s.L.Lock()
 	if s.iterating {
-		s.Cond.Wait()
+		s.Wait()
 	}
-	defer s.Cond.L.Unlock()
-	if !s.contains(m) {
-		return false
-	}
-	d := s.idx[m]
-	s.values = append(s.values[:d], s.values[d+1:]...)
-	for i, v := range s.values[d:] {
-		s.idx[v] = d + i
-	}
-	delete(s.idx, m)
-	return true
+	defer s.L.Unlock()
+	return s.set.Remove(m)
 }
 
-func (s *LockedOrdered[M]) Cardinality() int {
-	s.RWMutex.RLock()
-	defer s.RWMutex.RUnlock()
-	return len(s.values)
+func (s *lockedOrdered[M]) Cardinality() int {
+	if s == nil {
+		return 0
+	}
+	s.RLock()
+	defer s.RUnlock()
+	return s.set.Cardinality()
 }
 
 // Iterator yields all elements in the set in order. It holds a lock for the duration of iteration. Calling methods other than
 // `Contains` and `Cardinality` will block until the iteration is complete.
-func (s *LockedOrdered[M]) Iterator(yield func(M) bool) {
-	s.Cond.L.Lock()
+func (s *lockedOrdered[M]) Iterator(yield func(M) bool) {
+	s.L.Lock()
 	s.iterating = true
 	defer func() {
 		s.iterating = false
-		s.Cond.Broadcast()
-		s.Cond.L.Unlock()
+		s.Broadcast()
+		s.L.Unlock()
 	}()
 
-	for _, k := range s.values {
-		if !yield(k) {
-			return
-		}
-	}
+	s.set.Iterator(yield)
 }
 
-func (s *LockedOrdered[M]) Clone() Set[M] {
+func (s *lockedOrdered[M]) Clone() Set[M] {
 	return NewLockedOrderedFrom(s.Iterator)
+}
+
+// Ordered iteration yields the index and value of each element in the set in order.
+func (s *lockedOrdered[M]) Ordered(yield func(int, M) bool) {
+	s.L.Lock()
+	s.iterating = true
+	defer func() {
+		s.iterating = false
+		s.Broadcast()
+		s.L.Unlock()
+	}()
+
+	s.set.Ordered(yield)
+}
+
+func (s *lockedOrdered[M]) Backwards(yield func(int, M) bool) {
+	s.L.Lock()
+	s.iterating = true
+	defer func() {
+		s.iterating = false
+		s.Broadcast()
+		s.L.Unlock()
+	}()
+
+	s.set.Backwards(yield)
+}
+
+func (s *lockedOrdered[M]) NewEmptyOrdered() OrderedSet[M] {
+	return NewLockedOrdered[M]()
+}
+
+func (s *lockedOrdered[M]) NewEmpty() Set[M] {
+	return NewLockedOrdered[M]()
+}
+
+func (s *lockedOrdered[M]) Sort() {
+	s.L.Lock()
+	if s.iterating {
+		s.Wait()
+	}
+	defer s.L.Unlock()
+
+	s.set.Sort()
+}
+
+func (s *lockedOrdered[M]) At(i int) (M, bool) {
+	s.RLock()
+	defer s.RUnlock()
+
+	return s.set.At(i)
+}
+
+func (s *lockedOrdered[M]) Index(m M) int {
+	s.RLock()
+	defer s.RUnlock()
+
+	return s.set.Index(m)
+}
+
+func (s *lockedOrdered[M]) String() string {
+	s.RLock()
+	defer s.RUnlock()
+
+	return "Locked" + s.set.String()
 }

--- a/map.go
+++ b/map.go
@@ -1,33 +1,34 @@
 package set
 
-import "iter"
+import (
+	"fmt"
+	"iter"
+	"maps"
+	"slices"
+)
 
-// Map is a set implementation using the built in map type.
-// Instances of this type are not safe to be used concurrently.
-type Map[M comparable] map[M]struct{}
+type mapSet[M comparable] map[M]struct{}
 
-var _ Set[int] = Map[int]{}
-
-// New returns an empty MapSet instance.
-func New[M comparable]() Map[M] {
-	return make(Map[M])
+// New returns an empty Set[M] instance.
+func New[M comparable]() Set[M] {
+	return make(mapSet[M])
 }
 
-// NewFrom returns a new MapSet instance filled with the values from the sequence.
-func NewFrom[M comparable](seq iter.Seq[M]) Map[M] {
-	s := make(Map[M])
+// NewFrom returns a new Set[M] filled with the values from the sequence.
+func NewFrom[M comparable](seq iter.Seq[M]) Set[M] {
+	s := make(mapSet[M])
 	for x := range seq {
 		s.Add(x)
 	}
 	return s
 }
 
-func (s Map[M]) Contains(m M) bool {
+func (s mapSet[M]) Contains(m M) bool {
 	_, ok := s[m]
 	return ok
 }
 
-func (s Map[M]) Clear() int {
+func (s mapSet[M]) Clear() int {
 	n := len(s)
 	for k := range s {
 		delete(s, k)
@@ -35,7 +36,7 @@ func (s Map[M]) Clear() int {
 	return n
 }
 
-func (s Map[M]) Add(m M) bool {
+func (s mapSet[M]) Add(m M) bool {
 	if s.Contains(m) {
 		return false
 	}
@@ -43,7 +44,7 @@ func (s Map[M]) Add(m M) bool {
 	return true
 }
 
-func (s Map[M]) Remove(m M) bool {
+func (s mapSet[M]) Remove(m M) bool {
 	if !s.Contains(m) {
 		return false
 	}
@@ -51,12 +52,15 @@ func (s Map[M]) Remove(m M) bool {
 	return true
 }
 
-func (s Map[M]) Cardinality() int {
+func (s mapSet[M]) Cardinality() int {
+	if s == nil {
+		return 0
+	}
 	return len(s)
 }
 
 // Iterator yields all elements in the set.
-func (s Map[M]) Iterator(yield func(M) bool) {
+func (s mapSet[M]) Iterator(yield func(M) bool) {
 	for k := range s {
 		if !yield(k) {
 			return
@@ -64,6 +68,15 @@ func (s Map[M]) Iterator(yield func(M) bool) {
 	}
 }
 
-func (s Map[M]) Clone() Set[M] {
+func (s mapSet[M]) Clone() Set[M] {
 	return NewFrom(s.Iterator)
+}
+
+func (s mapSet[M]) NewEmpty() Set[M] {
+	return New[M]()
+}
+
+func (s mapSet[M]) String() string {
+	var m M
+	return fmt.Sprintf("Set[%T](%v)", m, slices.Collect(maps.Keys(s)))
 }

--- a/ordered_set.go
+++ b/ordered_set.go
@@ -1,0 +1,76 @@
+package set
+
+import (
+	"cmp"
+	"slices"
+)
+
+// OrderedSet is an extended set interface that implementations can implement to indicate that the set is ordered.
+// OrderedSet sets have a guaranteed order of elements when iterating over them and are restricted to types that are in
+// cmp.Ordered. The order of elements is not guaranteed for sets that do not implement this interface. OrderedSets will
+// always return an ordered set when cloning.
+type OrderedSet[M cmp.Ordered] interface {
+	Set[M]
+
+	// Ordered index, value iterator. The yield function is called for each element in the set in order. If the yield
+	// function returns false, the iteration is stopped. Changing the set while iterating over it is undefined. It may
+	// or may not be safe to change the set or allowed based on the implementation in use. Implementations must document
+	// their iteration safety.
+	Ordered(yield func(int, M) bool)
+
+	// Backwards index, value iterator. The yield function is called for each element in the set in reverse order. If the
+	// yield function returns false, the iteration is stopped. Changing the set while iterating over it is undefined. It
+	// may or may not be safe to change the set or allowed based on the implementation in use. Implementations must
+	// document their iteration safety.
+	Backwards(yield func(int, M) bool)
+
+	// At returns the element at the index. If the index is out of bounds, the second return value is false.
+	At(i int) (M, bool)
+
+	// Index returns the index of the element in the set, or -1 if not present.
+	Index(M) int
+
+	// Sort the set in ascending order in place.
+	Sort()
+
+	// NewEmptyOrdered returns a new empty ordered set of the same underlying type.
+	NewEmptyOrdered() OrderedSet[M]
+}
+
+// EqualOrdered returns true if the two OrderedSets contain the same elements in the same order.
+func EqualOrdered[K cmp.Ordered](a, b OrderedSet[K]) bool {
+	// can't be equal if they don't have the same cardinality
+	if a.Cardinality() != b.Cardinality() {
+		return false
+	}
+	bv := slices.Collect(b.Iterator)
+	for ai, ak := range a.Ordered {
+		if ak != bv[ai] {
+			return false
+		}
+	}
+	return true
+}
+
+// IsSorted returns true if the OrderedSet is sorted in ascending order.
+func IsSorted[K cmp.Ordered](s OrderedSet[K]) bool {
+	var prev K
+	for i, k := range s.Ordered {
+		if i != 0 && cmp.Less(k, prev) {
+			return false
+		}
+		prev = k
+	}
+	return true
+}
+
+// Reverse returns a new OrderedSet with the elements in the reverse order of the original OrderedSet.
+func Reverse[K cmp.Ordered](s OrderedSet[K]) OrderedSet[K] {
+	out := s.NewEmptyOrdered()
+	AppendSeq(out, func(yield func(k K) bool) {
+		s.Backwards(func(_ int, k K) bool {
+			return yield(k)
+		})
+	})
+	return out
+}

--- a/set.go
+++ b/set.go
@@ -5,6 +5,7 @@
 package set
 
 import (
+	"cmp"
 	"iter"
 	"slices"
 )
@@ -21,7 +22,7 @@ type Set[M comparable] interface {
 	// Clear removes all elements from the set and returns the number of elements removed.
 	Clear() int
 
-	// Clone returns a deep copy of the set.
+	// Clone returns a copy of the set. Ordered sets maintain their order.
 	Clone() Set[M]
 
 	// Contains returns true if the set contains the element.
@@ -35,9 +36,15 @@ type Set[M comparable] interface {
 
 	// Remove an element from the set. Returns true if the element was in the set.
 	Remove(M) bool
+
+	// NewEmpty returns a new empty set of the same underlying type. If the type is ordered, the new set will also be ordered.
+	NewEmpty() Set[M]
+
+	// String representation of the set.
+	String() string
 }
 
-// Elements returns a slice of all elements in the set. This is a convenience wrapper around slices.Collect(s.Iterator)
+// Elements of the set as a slice. This is a convenience wrapper around slices.Collect(s.Iterator)
 func Elements[K comparable](s Set[K]) []K {
 	return slices.Collect(s.Iterator)
 }
@@ -109,6 +116,9 @@ func SymmetricDifference[K comparable](a, b Set[K]) Set[K] {
 
 // Subset returns true if all elements in the first set are also in the second set.
 func Subset[K comparable](a, b Set[K]) bool {
+	if a.Cardinality() > b.Cardinality() {
+		return false
+	}
 	for k := range a.Iterator {
 		if !b.Contains(k) {
 			return false
@@ -119,11 +129,18 @@ func Subset[K comparable](a, b Set[K]) bool {
 
 // Superset returns true if all elements in the second set are also in the first set.
 func Superset[K comparable](a, b Set[K]) bool {
+	if a.Cardinality() < b.Cardinality() {
+		return false
+	}
 	return Subset(b, a)
 }
 
 // Equal returns true if the two sets contain the same elements.
 func Equal[K comparable](a, b Set[K]) bool {
+	// can't be equal if they don't have the same cardinality
+	if a.Cardinality() != b.Cardinality() {
+		return false
+	}
 	return Subset(a, b) && Subset(b, a)
 }
 
@@ -147,4 +164,81 @@ func Disjoint[K comparable](a, b Set[K]) bool {
 		}
 	}
 	return true
+}
+
+// Iter2 is a helper function that simplifies iterating over a set when an "index" is needed, by providing a pseudo-index
+// to the yield function. The index is not stable across iterations. The yield function is called for each element in the
+// set. If the yield function returns false, the iteration is stopped.
+//
+// Example:
+//
+//	for i, k := range Iter2(s.Iterator) {
+//	    fmt.Println(i, k)
+//	}
+func Iter2[K comparable](iter iter.Seq[K]) func(func(i int, k K) bool) {
+	var i int
+	return func(yield func(i int, k K) bool) {
+		for k := range iter {
+			if !yield(i, k) {
+				return
+			}
+			i++
+		}
+	}
+}
+
+// Max element in the set. Set must be a set of cmp.Ordered elements. Panics if the set is empty.
+func Max[K cmp.Ordered](s Set[K]) K {
+	if s.Cardinality() == 0 {
+		panic("empty set")
+	}
+
+	var mx K
+	for i, k := range Iter2(s.Iterator) {
+		if i == 0 {
+			mx = k
+			continue
+		}
+		mx = max(mx, k)
+	}
+	return mx
+}
+
+// Min element in the set. Set must be a set of cmp.Ordered elements. Panics if the set is empty.
+func Min[K cmp.Ordered](s Set[K]) K {
+	if s.Cardinality() == 0 {
+		panic("empty set")
+	}
+
+	var mn K
+	for i, k := range Iter2(s.Iterator) {
+		if i == 0 {
+			mn = k
+			continue
+		}
+		mn = min(mn, k)
+	}
+	return mn
+}
+
+func Chunk[K comparable](s Set[K], n int) iter.Seq[Set[K]] {
+	return func(yield func(Set[K]) bool) {
+		chunk := s.NewEmpty()
+		for i, v := range Iter2(s.Iterator) {
+			if i%n == 0 {
+				if chunk.Cardinality() > 0 {
+					if !yield(chunk) {
+						return
+					}
+				}
+				chunk = s.NewEmpty()
+				chunk.Add(v)
+			} else {
+				chunk.Add(v)
+			}
+		}
+		if chunk.Cardinality() > 0 {
+			yield(chunk)
+		}
+	}
 }

--- a/sync.go
+++ b/sync.go
@@ -1,27 +1,29 @@
 package set
 
 import (
+	"fmt"
 	"iter"
+	"slices"
 	"sync"
 )
 
-// SyncMap is a set implementation using the built in sync.Map type. Instances of this type are safe to be used
-// concurrently. All sync.Map characteristics apply. Iteration is done via sync.Map.Range.
-type SyncMap[M comparable] struct {
+type syncMap[M comparable] struct {
 	m sync.Map
 }
 
-var _ Set[int] = new(SyncMap[int])
+var _ Set[int] = new(syncMap[int])
 
-// NewSync returns an empty SyncMapSet instance.
-func NewSync[M comparable]() *SyncMap[M] {
-	return &SyncMap[M]{
+// NewSync returns an empty Set[M] that is backed by a sync.Map, making it safe for concurrent use.
+// Please read the documentation for [sync.Map] to understand the behavior of modifying the map.
+func NewSync[M comparable]() Set[M] {
+	return &syncMap[M]{
 		m: sync.Map{},
 	}
 }
 
-// NewSyncFrom returns a new SyncMapSet instance filled with the values from the sequence.
-func NewSyncFrom[M comparable](seq iter.Seq[M]) *SyncMap[M] {
+// NewSyncFrom returns a new Set[M] filled with the values from the sequence and is backed by a sync.Mao, making it safe
+// for concurrent use. Please read the documentation for [sync.Map] to understand the behavior of modifying the map.
+func NewSyncFrom[M comparable](seq iter.Seq[M]) Set[M] {
 	s := NewSync[M]()
 	for x := range seq {
 		s.Add(x)
@@ -29,12 +31,12 @@ func NewSyncFrom[M comparable](seq iter.Seq[M]) *SyncMap[M] {
 	return s
 }
 
-func (s *SyncMap[M]) Contains(m M) bool {
+func (s *syncMap[M]) Contains(m M) bool {
 	_, ok := s.m.Load(m)
 	return ok
 }
 
-func (s *SyncMap[M]) Clear() int {
+func (s *syncMap[M]) Clear() int {
 	var n int
 	s.m.Range(func(_, _ interface{}) bool {
 		n++
@@ -44,17 +46,20 @@ func (s *SyncMap[M]) Clear() int {
 	return n
 }
 
-func (s *SyncMap[M]) Add(m M) bool {
+func (s *syncMap[M]) Add(m M) bool {
 	_, loaded := s.m.LoadOrStore(m, struct{}{})
 	return !loaded
 }
 
-func (s *SyncMap[M]) Remove(m M) bool {
+func (s *syncMap[M]) Remove(m M) bool {
 	_, ok := s.m.LoadAndDelete(m)
 	return ok
 }
 
-func (s *SyncMap[M]) Cardinality() int {
+func (s *syncMap[M]) Cardinality() int {
+	if s == nil {
+		return 0
+	}
 	var n int
 	s.m.Range(func(_, _ interface{}) bool {
 		n++
@@ -65,12 +70,21 @@ func (s *SyncMap[M]) Cardinality() int {
 
 // Iterator yields all elements in the set. It is safe to call concurrently with other methods, but the order and
 // behavior is undefined, as per [sync.Map]'s `Range`.
-func (s *SyncMap[M]) Iterator(yield func(M) bool) {
+func (s *syncMap[M]) Iterator(yield func(M) bool) {
 	s.m.Range(func(key, _ interface{}) bool {
 		return yield(key.(M))
 	})
 }
 
-func (s *SyncMap[M]) Clone() Set[M] {
+func (s *syncMap[M]) Clone() Set[M] {
 	return NewSyncFrom(s.Iterator)
+}
+
+func (s *syncMap[M]) NewEmpty() Set[M] {
+	return NewSync[M]()
+}
+
+func (s *syncMap[M]) String() string {
+	var m M
+	return fmt.Sprintf("SyncSet[%T](%v)", m, slices.Collect(s.Iterator))
 }


### PR DESCRIPTION
made the set implementation types private

The locked variants now wrap another set implementation instead of re-implementing.

proper OrderedSet interface type

OrderedSet helpers: EqualOrdered, IsSorted & Reverse

2 New set methods: NewEmpty & String

Iter2 helper for pseudo idexed iteration

Max/Min/Chunk helpers