### PR TITLE
Expose concrete types

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,6 +1,20 @@
 # Changelog
 
-## Unreleased
+## v0.9.0
+
+* Renames
+  * func Map to func MapBy
+  * func New to func NewMap
+  * func NewFrom to func NewMapFrom
+  * func NewWith to func NewMapWith
+* Set types are now exported, so that ...
+* Concrete types can be used in structs and json.Unmarshaled to.
+  * sets.Map (basic set type)
+  * sets.Locked (basic locked set type)
+  * sets.Ordered (basic ordred set type)
+  * sets.LockedOrdered (basic locked+ordered set type)
+  * sets.SyncMap (sync.Map based set type)
+* Added more JSON tests, especially for above
 
 ## v0.8.0
 

--- a/README.MD
+++ b/README.MD
@@ -43,7 +43,6 @@ go get github.com/freeformz/sets
 ## JSON
 
 Sets marshal to/from JSON as JSON arrays.
-They must be initialized before doing so as the zero value of an interface is nil.
 A JSON array with repeated values unmarshaled to a Set will not preserve duplicates.
 An empty Set marshals to `[]`.
 OrderedSets preserve order when {un,}marshaling, while Sets do not.
@@ -71,7 +70,7 @@ These helpers work on all Set types, including OrderedSets.
 * `sets.Min(aSet)` : Returns the min element in the set as determined by the min builtin.
 * `sets.Chunk(aSet,n)` : Chunks the set into n sets of equal size. The last set will have fewer elements if the cardinality of the set is not a multiple of n.
 * `sets.IsEmpty(aSet)` : Returns true if the set is empty, otherwise false.
-* `sets.Map(aSet, func(v V) X { return ... }) bSet` : Maps the elements of the set to a new set.
+* `sets.MapBy(aSet, func(v V) X { return ... }) bSet` : Maps the elements of the set to a new set.
 * `sets.MapTo(aSet, bSet, func(v V) X { return ... })` : Maps the elements of aSet into bSet.
 * `sets.MapToSlice(aSet, func(v V) X { return ... }) aSlice` : Maps the elements of the set to a new slice.
 * `sets.Filter(aSet, func(v V) bool { return true/false }) bSet` : Filters the elements of the set and returns a new set.

--- a/examples_test.go
+++ b/examples_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func ExampleSet() {
-	ints := New[int]()
+	ints := NewMap[int]()
 	ints.Add(5)
 	ints.Add(1)
 	ints.Add(9)
@@ -150,7 +150,7 @@ func ExampleOrderedSet() {
 }
 
 func ExampleElements() {
-	ints := NewWith(5, 3, 2)
+	ints := NewMapWith(5, 3, 2)
 
 	// []T is returned
 	elements := Elements(ints)
@@ -164,7 +164,7 @@ func ExampleElements() {
 }
 
 func ExampleAppendSeq() {
-	ints := NewWith(5, 3)
+	ints := NewMapWith(5, 3)
 
 	// adds 2,4,1 to the set since 5 and 3 already exist
 	added := AppendSeq(ints, slices.Values([]int{5, 3, 2, 4, 1}))
@@ -173,7 +173,7 @@ func ExampleAppendSeq() {
 }
 
 func ExampleRemoveSeq() {
-	ints := NewWith(5, 3, 2)
+	ints := NewMapWith(5, 3, 2)
 
 	// removes 2 from the set since 5 and 3 exist
 	removed := RemoveSeq(ints, slices.Values([]int{2, 4, 1}))
@@ -182,8 +182,8 @@ func ExampleRemoveSeq() {
 }
 
 func ExampleUnion() {
-	a := NewWith(5, 3)
-	b := NewWith(3, 2)
+	a := NewMapWith(5, 3)
+	b := NewMapWith(3, 2)
 
 	c := Union(a, b)
 	out := make([]int, 0, c.Cardinality())
@@ -201,8 +201,8 @@ func ExampleUnion() {
 }
 
 func ExampleIntersection() {
-	a := NewWith(5, 3)
-	b := NewWith(3, 2)
+	a := NewMapWith(5, 3)
+	b := NewMapWith(3, 2)
 
 	c := Intersection(a, b)
 	out := make([]int, 0, c.Cardinality())
@@ -217,8 +217,8 @@ func ExampleIntersection() {
 }
 
 func ExampleDifference() {
-	a := NewWith(5, 3)
-	b := NewWith(3, 2)
+	a := NewMapWith(5, 3)
+	b := NewMapWith(3, 2)
 
 	c := Difference(a, b)
 	out := make([]int, 0, c.Cardinality())
@@ -233,8 +233,8 @@ func ExampleDifference() {
 }
 
 func ExampleSymmetricDifference() {
-	a := NewWith(5, 3)
-	b := NewWith(3, 2)
+	a := NewMapWith(5, 3)
+	b := NewMapWith(3, 2)
 
 	c := SymmetricDifference(a, b)
 	for i := range c.Iterator {
@@ -246,8 +246,8 @@ func ExampleSymmetricDifference() {
 }
 
 func ExampleSubset() {
-	a := NewWith(5, 3)
-	b := NewWith(5, 3, 2)
+	a := NewMapWith(5, 3)
+	b := NewMapWith(5, 3, 2)
 
 	if Subset(a, b) {
 		fmt.Println("a is a subset of b")
@@ -262,8 +262,8 @@ func ExampleSubset() {
 }
 
 func ExampleSuperset() {
-	a := NewWith(5, 3)
-	b := NewWith(5, 3, 2)
+	a := NewMapWith(5, 3)
+	b := NewMapWith(5, 3, 2)
 
 	if !Superset(a, b) {
 		fmt.Println("a is not a superset of b")
@@ -278,8 +278,8 @@ func ExampleSuperset() {
 }
 
 func ExampleEqual() {
-	a := NewWith(5, 3)
-	b := NewWith(5, 3)
+	a := NewMapWith(5, 3)
+	b := NewMapWith(5, 3)
 
 	if Equal(a, b) {
 		fmt.Println("a and b are equal")
@@ -303,7 +303,7 @@ func ExampleEqual() {
 }
 
 func ExampleContainsSeq() {
-	ints := New[int]()
+	ints := NewMap[int]()
 	if ContainsSeq(ints, slices.Values([]int{})) {
 		fmt.Println("Empty set contains empty sequence")
 	}
@@ -326,8 +326,8 @@ func ExampleContainsSeq() {
 }
 
 func ExampleDisjoint() {
-	a := NewWith(5, 3)
-	b := NewWith(2, 4)
+	a := NewMapWith(5, 3)
+	b := NewMapWith(2, 4)
 
 	if Disjoint(a, b) {
 		fmt.Println("a and b are disjoint")
@@ -368,7 +368,7 @@ func ExampleEqualOrdered() {
 }
 
 func ExampleMin() {
-	ints := NewWith(3, 2, 5)
+	ints := NewMapWith(3, 2, 5)
 
 	min := Min(ints)
 	fmt.Println(min)
@@ -376,7 +376,7 @@ func ExampleMin() {
 }
 
 func ExampleMax() {
-	ints := NewWith(3, 5, 2)
+	ints := NewMapWith(3, 5, 2)
 
 	max := Max(ints)
 	fmt.Println(max)
@@ -492,8 +492,8 @@ func Example_json() {
 	// OrderedSet[float32]([1 1.2 1.3 1.4 1.5])
 }
 
-func ExampleNewWith() {
-	set := NewWith("a", "b", "c", "b")
+func ExampleNewMapWith() {
+	set := NewMapWith("a", "b", "c", "b")
 	fmt.Println(set.Cardinality())
 
 	// Output: 3
@@ -536,15 +536,15 @@ func ExampleNewLockedOrderedWith() {
 	// c
 }
 
-func ExampleNewSyncWith() {
-	set := NewSyncWith("a", "b", "c", "b")
+func ExampleNewSyncMapWith() {
+	set := NewSyncMapWith("a", "b", "c", "b")
 	fmt.Println(set.Cardinality())
 
 	// Output: 3
 }
 
-func ExampleNew() {
-	set := New[string]()
+func ExampleNewMap() {
+	set := NewMap[string]()
 	set.Add("a")
 	set.Add("b")
 	set.Add("c")
@@ -603,8 +603,8 @@ func ExampleNewLockedOrdered() {
 	// c
 }
 
-func ExampleNewSync() {
-	set := NewSync[string]()
+func ExampleNewSyncMap() {
+	set := NewSyncMap[string]()
 	set.Add("a")
 	set.Add("b")
 	set.Add("c")
@@ -614,9 +614,9 @@ func ExampleNewSync() {
 	// Output: 3
 }
 
-func ExampleNewFrom() {
+func ExampleNewMapFrom() {
 	m := []string{"a", "b", "c", "b"}
-	set := NewFrom(slices.Values(m))
+	set := NewMapFrom(slices.Values(m))
 	fmt.Println(set.Cardinality())
 
 	// Output: 3
@@ -662,16 +662,16 @@ func ExampleNewLockedOrderedFrom() {
 	// c
 }
 
-func ExampleNewSyncFrom() {
+func ExampleNewSyncMapFrom() {
 	m := []string{"a", "b", "c", "b"}
-	set := NewSyncFrom(slices.Values(m))
+	set := NewSyncMapFrom(slices.Values(m))
 	fmt.Println(set.Cardinality())
 
 	// Output: 3
 }
 
 func ExampleNewLockedWrapping() {
-	set := NewWith("a", "b", "c", "b")
+	set := NewMapWith("a", "b", "c", "b")
 
 	wrapped := NewLockedWrapping(set)
 	// wrapped is safe for concurrent use
@@ -691,7 +691,7 @@ func ExampleNewLockedOrderedWrapping() {
 }
 
 func ExampleIsEmpty() {
-	set := New[int]()
+	set := NewMap[int]()
 	if IsEmpty(set) {
 		fmt.Println("set is empty")
 	}
@@ -705,17 +705,17 @@ func ExampleIsEmpty() {
 	// set is not empty
 }
 
-func ExampleMap() {
-	set := NewWith(1, 2, 3)
+func ExampleMapBy() {
+	set := NewMapWith(1, 2, 3)
 
-	mapped := Map(set, func(i int) int {
+	mapped := MapBy(set, func(i int) int {
 		return i * 2
 	})
 	for i := range mapped.Iterator {
 		fmt.Println(i)
 	}
 
-	mapped2 := Map(set, func(i int) string {
+	mapped2 := MapBy(set, func(i int) string {
 		return fmt.Sprintf("%d", i)
 	})
 	for i := range mapped2.Iterator {
@@ -733,7 +733,7 @@ func ExampleMap() {
 func ExampleMapTo() {
 	set := NewOrderedWith(3, 1, 2)
 
-	dest := New[string]()
+	dest := NewMap[string]()
 	MapTo(set, dest, func(i int) string {
 		return fmt.Sprintf("%d=%d*2", i*2, i)
 	})
@@ -747,7 +747,7 @@ func ExampleMapTo() {
 }
 
 func ExampleMapToSlice() {
-	set := NewWith(3, 1, 2)
+	set := NewMapWith(3, 1, 2)
 
 	mapped := MapToSlice(set, func(i int) string {
 		return fmt.Sprintf("%d=%d*2", i*2, i)
@@ -762,7 +762,7 @@ func ExampleMapToSlice() {
 }
 
 func ExampleFilter() {
-	set := NewWith(3, 0, 1, 2, 4)
+	set := NewMapWith(3, 0, 1, 2, 4)
 
 	filtered := Filter(set, func(i int) bool {
 		return i > 2
@@ -776,7 +776,7 @@ func ExampleFilter() {
 }
 
 func ExampleReduce() {
-	set := NewWith(3, 1, 2)
+	set := NewMapWith(3, 1, 2)
 
 	sum := Reduce(set, 0, func(agg, v int) int {
 		return agg + v
@@ -801,7 +801,7 @@ func ExampleReduceRight() {
 }
 
 func ExampleForEach() {
-	set := NewWith(3, 1, 2)
+	set := NewMapWith(3, 1, 2)
 
 	ForEach(set, func(i int) {
 		fmt.Println(i)

--- a/locker.go
+++ b/locker.go
@@ -1,0 +1,10 @@
+package sets
+
+type locker interface {
+	Lock()
+	Unlock()
+	RLock()
+	RUnlock()
+	Wait()
+	Broadcast()
+}

--- a/map.go
+++ b/map.go
@@ -8,37 +8,39 @@ import (
 	"slices"
 )
 
-type mapSet[M comparable] struct {
+type Map[M comparable] struct {
 	set map[M]struct{}
 }
 
-// New returns an empty Set[M] instance.
-func New[M comparable]() Set[M] {
-	return &mapSet[M]{
+var x Set[int] = new(Map[int])
+
+// NewMap returns an empty Set[M] instance.
+func NewMap[M comparable]() *Map[M] {
+	return &Map[M]{
 		set: make(map[M]struct{}),
 	}
 }
 
-// NewFrom returns a new Set[M] filled with the values from the sequence.
-func NewFrom[M comparable](seq iter.Seq[M]) Set[M] {
-	s := New[M]()
+// NewMapFrom returns a new Set[M] filled with the values from the sequence.
+func NewMapFrom[M comparable](seq iter.Seq[M]) *Map[M] {
+	s := NewMap[M]()
 	for x := range seq {
 		s.Add(x)
 	}
 	return s
 }
 
-// NewWith the values provides. Duplicates are removed.
-func NewWith[M comparable](m ...M) Set[M] {
-	return NewFrom(slices.Values(m))
+// NewMapWith the values provides. Duplicates are removed.
+func NewMapWith[M comparable](m ...M) *Map[M] {
+	return NewMapFrom(slices.Values(m))
 }
 
-func (s *mapSet[M]) Contains(m M) bool {
+func (s *Map[M]) Contains(m M) bool {
 	_, ok := s.set[m]
 	return ok
 }
 
-func (s *mapSet[M]) Clear() int {
+func (s *Map[M]) Clear() int {
 	n := len(s.set)
 	for k := range s.set {
 		delete(s.set, k)
@@ -46,7 +48,7 @@ func (s *mapSet[M]) Clear() int {
 	return n
 }
 
-func (s *mapSet[M]) Add(m M) bool {
+func (s *Map[M]) Add(m M) bool {
 	if s.Contains(m) {
 		return false
 	}
@@ -54,7 +56,7 @@ func (s *mapSet[M]) Add(m M) bool {
 	return true
 }
 
-func (s *mapSet[M]) Remove(m M) bool {
+func (s *Map[M]) Remove(m M) bool {
 	if !s.Contains(m) {
 		return false
 	}
@@ -62,12 +64,12 @@ func (s *mapSet[M]) Remove(m M) bool {
 	return true
 }
 
-func (s *mapSet[M]) Cardinality() int {
+func (s *Map[M]) Cardinality() int {
 	return len(s.set)
 }
 
 // Iterator yields all elements in the set.
-func (s *mapSet[M]) Iterator(yield func(M) bool) {
+func (s *Map[M]) Iterator(yield func(M) bool) {
 	for k := range s.set {
 		if !yield(k) {
 			return
@@ -75,15 +77,15 @@ func (s *mapSet[M]) Iterator(yield func(M) bool) {
 	}
 }
 
-func (s *mapSet[M]) Clone() Set[M] {
-	return NewFrom(s.Iterator)
+func (s *Map[M]) Clone() Set[M] {
+	return NewMapFrom(s.Iterator)
 }
 
-func (s *mapSet[M]) NewEmpty() Set[M] {
-	return New[M]()
+func (s *Map[M]) NewEmpty() Set[M] {
+	return NewMap[M]()
 }
 
-func (s *mapSet[M]) Pop() (M, bool) {
+func (s *Map[M]) Pop() (M, bool) {
 	for k := range s.set {
 		delete(s.set, k)
 		return k, true
@@ -92,12 +94,12 @@ func (s *mapSet[M]) Pop() (M, bool) {
 	return m, false
 }
 
-func (s *mapSet[M]) String() string {
+func (s *Map[M]) String() string {
 	var m M
 	return fmt.Sprintf("Set[%T](%v)", m, slices.Collect(maps.Keys(s.set)))
 }
 
-func (s *mapSet[M]) MarshalJSON() ([]byte, error) {
+func (s *Map[M]) MarshalJSON() ([]byte, error) {
 	v := slices.Collect(s.Iterator)
 	if len(v) == 0 {
 		return []byte("[]"), nil
@@ -110,13 +112,16 @@ func (s *mapSet[M]) MarshalJSON() ([]byte, error) {
 	return d, nil
 }
 
-func (s *mapSet[M]) UnmarshalJSON(d []byte) error {
+func (s *Map[M]) UnmarshalJSON(d []byte) error {
 	var um []M
 	if err := json.Unmarshal(d, &um); err != nil {
 		return fmt.Errorf("unmarshaling map set: %w", err)
 	}
 
 	s.Clear()
+	if s.set == nil {
+		s.set = make(map[M]struct{})
+	}
 	for _, m := range um {
 		s.Add(m)
 	}

--- a/set.go
+++ b/set.go
@@ -246,9 +246,9 @@ func IsEmpty[K comparable](s Set[K]) bool {
 	return s.Cardinality() == 0
 }
 
-// Map applies the function to each element in the set and returns a new set with the results.
-func Map[K comparable, V comparable](s Set[K], f func(K) V) Set[V] {
-	m := New[V]()
+// MapBy applies the function to each element in the set and returns a new set with the results.
+func MapBy[K comparable, V comparable](s Set[K], f func(K) V) Set[V] {
+	m := NewMap[V]()
 	for k := range s.Iterator {
 		m.Add(f(k))
 	}

--- a/sync.go
+++ b/sync.go
@@ -22,7 +22,7 @@ func NewSyncMap[M comparable]() *SyncMap[M] {
 	}
 }
 
-// NewSyncMapFrom returns a new Set[M] filled with the values from the sequence and is backed by a sync.Mao, making it safe
+// NewSyncMapFrom returns a new Set[M] filled with the values from the sequence and is backed by a sync.Map, making it safe
 // for concurrent use. Please read the documentation for [sync.Map] to understand the behavior of modifying the map.
 func NewSyncMapFrom[M comparable](seq iter.Seq[M]) *SyncMap[M] {
 	s := NewSyncMap[M]()

--- a/sync.go
+++ b/sync.go
@@ -32,7 +32,7 @@ func NewSyncMapFrom[M comparable](seq iter.Seq[M]) *SyncMap[M] {
 	return s
 }
 
-// NewSyncMapWith returns a new Set[M] filled with the values provided and is backed by a sync.Mao, making it safe
+// NewSyncMapWith returns a new Set[M] filled with the values provided and is backed by a sync.Map, making it safe
 // for concurrent use. Please read the documentation for [sync.Map] to understand the behavior of modifying the map.
 func NewSyncMapWith[M comparable](m ...M) *SyncMap[M] {
 	return NewSyncMapFrom(slices.Values(m))

--- a/sync.go
+++ b/sync.go
@@ -8,42 +8,42 @@ import (
 	"sync"
 )
 
-type syncMap[M comparable] struct {
+type SyncMap[M comparable] struct {
 	m sync.Map
 }
 
-var _ Set[int] = new(syncMap[int])
+var _ Set[int] = new(SyncMap[int])
 
-// NewSync returns an empty Set[M] that is backed by a sync.Map, making it safe for concurrent use.
+// NewSyncMap returns an empty Set[M] that is backed by a sync.Map, making it safe for concurrent use.
 // Please read the documentation for [sync.Map] to understand the behavior of modifying the map.
-func NewSync[M comparable]() Set[M] {
-	return &syncMap[M]{
+func NewSyncMap[M comparable]() *SyncMap[M] {
+	return &SyncMap[M]{
 		m: sync.Map{},
 	}
 }
 
-// NewSyncFrom returns a new Set[M] filled with the values from the sequence and is backed by a sync.Mao, making it safe
+// NewSyncMapFrom returns a new Set[M] filled with the values from the sequence and is backed by a sync.Mao, making it safe
 // for concurrent use. Please read the documentation for [sync.Map] to understand the behavior of modifying the map.
-func NewSyncFrom[M comparable](seq iter.Seq[M]) Set[M] {
-	s := NewSync[M]()
+func NewSyncMapFrom[M comparable](seq iter.Seq[M]) *SyncMap[M] {
+	s := NewSyncMap[M]()
 	for x := range seq {
 		s.Add(x)
 	}
 	return s
 }
 
-// NewSyncWith returns a new Set[M] filled with the values provided and is backed by a sync.Mao, making it safe
+// NewSyncMapWith returns a new Set[M] filled with the values provided and is backed by a sync.Mao, making it safe
 // for concurrent use. Please read the documentation for [sync.Map] to understand the behavior of modifying the map.
-func NewSyncWith[M comparable](m ...M) Set[M] {
-	return NewSyncFrom(slices.Values(m))
+func NewSyncMapWith[M comparable](m ...M) *SyncMap[M] {
+	return NewSyncMapFrom(slices.Values(m))
 }
 
-func (s *syncMap[M]) Contains(m M) bool {
+func (s *SyncMap[M]) Contains(m M) bool {
 	_, ok := s.m.Load(m)
 	return ok
 }
 
-func (s *syncMap[M]) Clear() int {
+func (s *SyncMap[M]) Clear() int {
 	var n int
 	s.m.Range(func(_, _ interface{}) bool {
 		n++
@@ -53,12 +53,12 @@ func (s *syncMap[M]) Clear() int {
 	return n
 }
 
-func (s *syncMap[M]) Add(m M) bool {
+func (s *SyncMap[M]) Add(m M) bool {
 	_, loaded := s.m.LoadOrStore(m, struct{}{})
 	return !loaded
 }
 
-func (s *syncMap[M]) Pop() (M, bool) {
+func (s *SyncMap[M]) Pop() (M, bool) {
 	var m M
 	var ok bool
 
@@ -73,12 +73,12 @@ func (s *syncMap[M]) Pop() (M, bool) {
 	return m, ok
 }
 
-func (s *syncMap[M]) Remove(m M) bool {
+func (s *SyncMap[M]) Remove(m M) bool {
 	_, ok := s.m.LoadAndDelete(m)
 	return ok
 }
 
-func (s *syncMap[M]) Cardinality() int {
+func (s *SyncMap[M]) Cardinality() int {
 	if s == nil {
 		return 0
 	}
@@ -92,26 +92,26 @@ func (s *syncMap[M]) Cardinality() int {
 
 // Iterator yields all elements in the set. It is safe to call concurrently with other methods, but the order and
 // behavior is undefined, as per [sync.Map]'s `Range`.
-func (s *syncMap[M]) Iterator(yield func(M) bool) {
+func (s *SyncMap[M]) Iterator(yield func(M) bool) {
 	s.m.Range(func(key, _ interface{}) bool {
 		return yield(key.(M))
 	})
 }
 
-func (s *syncMap[M]) Clone() Set[M] {
-	return NewSyncFrom(s.Iterator)
+func (s *SyncMap[M]) Clone() Set[M] {
+	return NewSyncMapFrom(s.Iterator)
 }
 
-func (s *syncMap[M]) NewEmpty() Set[M] {
-	return NewSync[M]()
+func (s *SyncMap[M]) NewEmpty() Set[M] {
+	return NewSyncMap[M]()
 }
 
-func (s *syncMap[M]) String() string {
+func (s *SyncMap[M]) String() string {
 	var m M
 	return fmt.Sprintf("SyncSet[%T](%v)", m, slices.Collect(s.Iterator))
 }
 
-func (s *syncMap[M]) MarshalJSON() ([]byte, error) {
+func (s *SyncMap[M]) MarshalJSON() ([]byte, error) {
 	v := slices.Collect(s.Iterator)
 	if len(v) == 0 {
 		return []byte("[]"), nil
@@ -124,7 +124,7 @@ func (s *syncMap[M]) MarshalJSON() ([]byte, error) {
 	return d, nil
 }
 
-func (s *syncMap[M]) UnmarshalJSON(d []byte) error {
+func (s *SyncMap[M]) UnmarshalJSON(d []byte) error {
 	var x []M
 	if err := json.Unmarshal(d, &x); err != nil {
 		return fmt.Errorf("unmarshaling sync set: %w", err)


### PR DESCRIPTION
* Renames
  * func Map to func MapBy
  * func New to func NewMap
  * func NewFrom to func NewMapFrom
  * func NewWith to func NewMapWith
* Set types are now exported, so that ...
* Concrete types can be used in structs and json.Unmarshaled to.
  * sets.Map (basic set type)
  * sets.Locked (basic locked set type)
  * sets.Ordered (basic ordred set type)
  * sets.LockedOrdered (basic locked+ordered set type)
  * sets.SyncMap (sync.Map based set type)
* Added more JSON tests, especially for above

#minor