### PR TITLE
feat: Add Any, All, ContainsAll, ContainsAny, Random, First, Last, and driver.Valuer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .aider*
+.claude/settings.local.json

--- a/README.MD
+++ b/README.MD
@@ -51,6 +51,10 @@ OrderedSets preserve order when {un,}marshaling, while Sets do not.
 
 Sets of types that don't have a JSON equivalent can't be marshaled to and/or from JSON w/o an error. For instance a Set of an interface type can marshal to json, but can't then un-marshal back to Go w/o an error.
 
+## SQL
+
+All set types implement `sql.Scanner` and `driver.Valuer`, allowing them to be used directly with `database/sql`. Values are stored as JSON arrays.
+
 ## Set Helpers
 
 These helpers work on all Set types, including OrderedSets.
@@ -79,6 +83,11 @@ These helpers work on all Set types, including OrderedSets.
 * `sets.Reduce(aSet, X, func(X, K) X { return ... }) X` : Reduces the set to a single value.
 * `sets.ForEach(aSet, func(v V))` : calls the provided function with each set member.
 * `sets.FilterTo(aSet, bSet, func(v V) bool { return true/false })` : Filters the elements of aSet and adds matching elements to bSet.
+* `sets.Any(aSet, func(v V) bool { return true/false })` : Returns true if any element in the set satisfies the predicate. Short-circuits on the first match.
+* `sets.All(aSet, func(v V) bool { return true/false })` : Returns true if all elements in the set satisfy the predicate. Short-circuits on the first non-match.
+* `sets.ContainsAll(aSet, elements...)` : Returns true if the set contains all of the provided elements.
+* `sets.ContainsAny(aSet, elements...)` : Returns true if the set contains at least one of the provided elements.
+* `sets.Random(aSet)` : Returns a random element from the set without removing it. O(1) for ordered sets, O(n) for unordered sets.
 
 ## OrderedSet Helpers
 
@@ -90,6 +99,8 @@ These helpers work on all OrderedSet types.
 * `sets.Sorted(aOrderedSet)` : Return a copy of aOrderedSet with the elements sorted in ascending order. Does not modify the original set.
 * `sets.ReduceRight(aSet, X, func(X, K) X { return ... }) X` : Reduces the set to a single value in reverse order.
 * `sets.ForEachRight(aSet, func(K) { ... })` : calls the provided function with each set member in reverse order.
+* `sets.First(aOrderedSet)` : Returns the first element of the ordered set, or (zero, false) if empty.
+* `sets.Last(aOrderedSet)` : Returns the last element of the ordered set, or (zero, false) if empty.
 
 ## Custom Set Types
 

--- a/examples_test.go
+++ b/examples_test.go
@@ -823,3 +823,115 @@ func ExampleForEachRight() {
 	// 1
 	// 3
 }
+
+func ExampleAny() {
+	set := NewWith(1, 2, 3, 4, 5)
+
+	if Any(set, func(i int) bool { return i > 3 }) {
+		fmt.Println("set has element > 3")
+	}
+
+	if !Any(set, func(i int) bool { return i > 10 }) {
+		fmt.Println("set has no element > 10")
+	}
+	// Output:
+	// set has element > 3
+	// set has no element > 10
+}
+
+func ExampleAll() {
+	set := NewWith(2, 4, 6)
+
+	if All(set, func(i int) bool { return i%2 == 0 }) {
+		fmt.Println("all elements are even")
+	}
+
+	set.Add(3)
+	if !All(set, func(i int) bool { return i%2 == 0 }) {
+		fmt.Println("not all elements are even")
+	}
+	// Output:
+	// all elements are even
+	// not all elements are even
+}
+
+func ExampleContainsAll() {
+	set := NewWith(1, 2, 3, 4, 5)
+
+	if ContainsAll(set, 1, 3, 5) {
+		fmt.Println("set contains 1, 3, and 5")
+	}
+
+	if !ContainsAll(set, 1, 6) {
+		fmt.Println("set does not contain both 1 and 6")
+	}
+	// Output:
+	// set contains 1, 3, and 5
+	// set does not contain both 1 and 6
+}
+
+func ExampleContainsAny() {
+	set := NewWith(1, 2, 3)
+
+	if ContainsAny(set, 3, 4, 5) {
+		fmt.Println("set contains at least one of 3, 4, 5")
+	}
+
+	if !ContainsAny(set, 6, 7, 8) {
+		fmt.Println("set contains none of 6, 7, 8")
+	}
+	// Output:
+	// set contains at least one of 3, 4, 5
+	// set contains none of 6, 7, 8
+}
+
+func ExampleRandom() {
+	set := NewWith(42)
+
+	// with a single element, Random always returns that element
+	v, ok := Random(set)
+	if ok {
+		fmt.Println(v)
+	}
+
+	empty := New[int]()
+	_, ok = Random(empty)
+	if !ok {
+		fmt.Println("empty set")
+	}
+	// Output:
+	// 42
+	// empty set
+}
+
+func ExampleFirst() {
+	set := NewOrderedWith(5, 3, 1)
+
+	if v, ok := First(set); ok {
+		fmt.Println(v)
+	}
+
+	empty := NewOrdered[int]()
+	if _, ok := First(empty); !ok {
+		fmt.Println("empty set")
+	}
+	// Output:
+	// 5
+	// empty set
+}
+
+func ExampleLast() {
+	set := NewOrderedWith(5, 3, 1)
+
+	if v, ok := Last(set); ok {
+		fmt.Println(v)
+	}
+
+	empty := NewOrdered[int]()
+	if _, ok := Last(empty); !ok {
+		fmt.Println("empty set")
+	}
+	// Output:
+	// 1
+	// empty set
+}

--- a/locked.go
+++ b/locked.go
@@ -1,6 +1,7 @@
 package sets
 
 import (
+	"database/sql/driver"
 	"encoding/json"
 	"fmt"
 	"iter"
@@ -17,6 +18,7 @@ type Locked[M comparable] struct {
 }
 
 var _ Set[int] = new(Locked[int])
+var _ driver.Valuer = new(Locked[int])
 
 // NewLocked returns an empty *Locked[M] that is safe for concurrent use.
 func NewLocked[M comparable]() *Locked[M] {
@@ -122,6 +124,11 @@ func (s *Locked[M]) String() string {
 	s.RLock()
 	defer s.RUnlock()
 	return "Locked" + s.set.String()
+}
+
+// Value implements the driver.Valuer interface. It returns the JSON representation of the set.
+func (s *Locked[M]) Value() (driver.Value, error) {
+	return s.MarshalJSON()
 }
 
 // MarshalJSON implements json.Marshaler. It will marshal the set into a JSON array of the elements in the set. If the

--- a/locked_ordered.go
+++ b/locked_ordered.go
@@ -2,6 +2,7 @@ package sets
 
 import (
 	"cmp"
+	"database/sql/driver"
 	"encoding/json"
 	"fmt"
 	"iter"
@@ -16,6 +17,7 @@ type LockedOrdered[M cmp.Ordered] struct {
 }
 
 var _ Set[int] = new(LockedOrdered[int])
+var _ driver.Valuer = new(LockedOrdered[int])
 
 // NewLockedOrdered returns an empty *LockedOrdered[M] instance that is safe for concurrent use.
 func NewLockedOrdered[M cmp.Ordered]() *LockedOrdered[M] {
@@ -168,6 +170,11 @@ func (s *LockedOrdered[M]) String() string {
 	defer s.RUnlock()
 
 	return "Locked" + s.set.String()
+}
+
+// Value implements the driver.Valuer interface. It returns the JSON representation of the set.
+func (s *LockedOrdered[M]) Value() (driver.Value, error) {
+	return s.MarshalJSON()
 }
 
 // MarshalJSON implements json.Marshaler. It will marshal the set to JSON. It returns a JSON array of the elements in

--- a/map.go
+++ b/map.go
@@ -1,6 +1,7 @@
 package sets
 
 import (
+	"database/sql/driver"
 	"encoding/json"
 	"fmt"
 	"iter"
@@ -15,6 +16,7 @@ type Map[M comparable] struct {
 }
 
 var _ Set[int] = new(Map[int])
+var _ driver.Valuer = new(Map[int])
 
 // New returns an empty *Map[M] instance.
 func New[M comparable]() *Map[M] {
@@ -142,6 +144,11 @@ func (s *Map[M]) UnmarshalJSON(d []byte) error {
 	}
 
 	return nil
+}
+
+// Value implements the driver.Valuer interface. It returns the JSON representation of the set.
+func (s *Map[M]) Value() (driver.Value, error) {
+	return s.MarshalJSON()
 }
 
 // scanValue is a helper function that implements the common logic for scanning values into sets.

--- a/ordered.go
+++ b/ordered.go
@@ -2,6 +2,7 @@ package sets
 
 import (
 	"cmp"
+	"database/sql/driver"
 	"encoding/json"
 	"fmt"
 	"iter"
@@ -15,6 +16,7 @@ type Ordered[M cmp.Ordered] struct {
 }
 
 var _ OrderedSet[int] = new(Ordered[int])
+var _ driver.Valuer = new(Ordered[int])
 
 // NewOrdered returns an empty *Ordered[M].
 func NewOrdered[M cmp.Ordered]() *Ordered[M] {
@@ -177,6 +179,11 @@ func (s *Ordered[M]) Index(m M) int {
 func (s *Ordered[M]) String() string {
 	var m M
 	return fmt.Sprintf("OrderedSet[%T](%v)", m, s.values)
+}
+
+// Value implements the driver.Valuer interface. It returns the JSON representation of the set.
+func (s *Ordered[M]) Value() (driver.Value, error) {
+	return s.MarshalJSON()
 }
 
 // MarshalJSON implements json.Marshaler. It will marshal the set into a JSON array of the elements in the set. If the

--- a/ordered_set.go
+++ b/ordered_set.go
@@ -98,3 +98,13 @@ func ForEachRight[K cmp.Ordered](s OrderedSet[K], fn func(k K)) {
 		fn(k)
 	}
 }
+
+// First returns the first element of the ordered set. If the set is empty, the second return value is false.
+func First[K cmp.Ordered](s OrderedSet[K]) (K, bool) {
+	return s.At(0)
+}
+
+// Last returns the last element of the ordered set. If the set is empty, the second return value is false.
+func Last[K cmp.Ordered](s OrderedSet[K]) (K, bool) {
+	return s.At(s.Cardinality() - 1)
+}

--- a/set.go
+++ b/set.go
@@ -7,6 +7,7 @@ package sets
 import (
 	"cmp"
 	"iter"
+	"math/rand/v2"
 	"slices"
 )
 
@@ -310,4 +311,67 @@ func ForEach[K comparable](s Set[K], f func(K)) {
 	for k := range s.Iterator {
 		f(k)
 	}
+}
+
+// Any returns true if any element in the set satisfies the predicate. Returns false for an empty set.
+func Any[K comparable](s Set[K], f func(K) bool) bool {
+	for k := range s.Iterator {
+		if f(k) {
+			return true
+		}
+	}
+	return false
+}
+
+// All returns true if all elements in the set satisfy the predicate. Returns true for an empty set (vacuous truth).
+func All[K comparable](s Set[K], f func(K) bool) bool {
+	for k := range s.Iterator {
+		if !f(k) {
+			return false
+		}
+	}
+	return true
+}
+
+// ContainsAll returns true if the set contains all of the provided elements. Returns true if no elements are provided (vacuous truth).
+func ContainsAll[K comparable](s Set[K], elements ...K) bool {
+	for _, k := range elements {
+		if !s.Contains(k) {
+			return false
+		}
+	}
+	return true
+}
+
+// ContainsAny returns true if the set contains at least one of the provided elements. Returns false if no elements are provided.
+func ContainsAny[K comparable](s Set[K], elements ...K) bool {
+	for _, k := range elements {
+		if s.Contains(k) {
+			return true
+		}
+	}
+	return false
+}
+
+// Random returns a random element from the set without removing it. The second return value is false if the set is empty.
+// For ordered sets, this is O(1) via indexed access. For unordered sets, this is O(n) via iteration.
+func Random[K comparable](s Set[K]) (K, bool) {
+	n := s.Cardinality()
+	if n == 0 {
+		var zero K
+		return zero, false
+	}
+	if idx, ok := s.(interface{ At(int) (K, bool) }); ok {
+		return idx.At(rand.IntN(n))
+	}
+	skip := rand.IntN(n)
+	i := 0
+	for k := range s.Iterator {
+		if i == skip {
+			return k, true
+		}
+		i++
+	}
+	var zero K
+	return zero, false
 }

--- a/sync.go
+++ b/sync.go
@@ -1,6 +1,7 @@
 package sets
 
 import (
+	"database/sql/driver"
 	"encoding/json"
 	"fmt"
 	"iter"
@@ -14,6 +15,7 @@ type SyncMap[M comparable] struct {
 }
 
 var _ Set[int] = new(SyncMap[int])
+var _ driver.Valuer = new(SyncMap[int])
 
 // NewSyncMap returns an empty Set[M] that is backed by a sync.Map, making it safe for concurrent use.
 // Please read the documentation for [sync.Map] to understand the behavior of modifying the map.
@@ -123,6 +125,11 @@ func (s *SyncMap[M]) MarshalJSON() ([]byte, error) {
 		return d, fmt.Errorf("marshaling sync set: %w", err)
 	}
 	return d, nil
+}
+
+// Value implements the driver.Valuer interface. It returns the JSON representation of the set.
+func (s *SyncMap[M]) Value() (driver.Value, error) {
+	return s.MarshalJSON()
 }
 
 func (s *SyncMap[M]) UnmarshalJSON(d []byte) error {


### PR DESCRIPTION
## Summary

- Add `Any`/`All` predicate functions with short-circuit evaluation
- Add `ContainsAll`/`ContainsAny` variadic convenience functions for membership checks
- Add `Random` for non-destructive random element selection (O(1) for ordered sets via `At`, O(n) for unordered)
- Add `First`/`Last` accessors for `OrderedSet`
- Implement `driver.Valuer` on all 5 set types (`Map`, `SyncMap`, `Locked`, `Ordered`, `LockedOrdered`) to complement existing `sql.Scanner`
- Update README with new SQL section and all new function documentation

## Test plan

- [x] State machine actions added for `Any`, `All`, `ContainsAll`, `ContainsAny`, `Random`, and `Valuer` — tested across all 5 set types via rapid property-based testing
- [x] Dedicated `TestFirst_Last_Ordered` and `TestFirst_Last_LockedOrdered` tests
- [x] Example tests for all new functions
- [x] `go test -v -race ./...` passes
- [x] `go vet ./...` clean
- [x] `staticcheck ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)