### PR TITLE
fix: Equal, Map lookup, and ContainsSeq correctness improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ When bumping the minimum Go version, the commit message should include `#minor` 
 
 ## Conventions
 
-- **Zero-value style**: Use `var x T` instead of `x := T{}` or `x := T's zero value`.
+- **Zero-value style**: Use `var x T` instead of `x := T{}`; refer to this as "T's zero value" in prose.
 - **Tests are the spec**: When modifying implementations, do not change tests. Treat test failures as implementation bugs.
 - **Mathematical correctness**: Prefer mathematically correct semantics (e.g., vacuous truth for empty predicates).
 - **Commit messages**: Use conventional commits (`feat:`, `fix:`, `docs:`, etc.).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,13 @@ All types implement `json.Marshaler`/`json.Unmarshaler` and `sql.Scanner`. The `
 
 When bumping the minimum Go version, the commit message should include `#minor` to trigger a minor version bump.
 
+## Conventions
+
+- **Zero-value style**: Use `var x T` instead of `x := T{}` or `x := T's zero value`.
+- **Tests are the spec**: When modifying implementations, do not change tests. Treat test failures as implementation bugs.
+- **Mathematical correctness**: Prefer mathematically correct semantics (e.g., vacuous truth for empty predicates).
+- **Commit messages**: Use conventional commits (`feat:`, `fix:`, `docs:`, etc.).
+
 ## Testing
 
 Tests use property-based state machine testing via `pgregory.net/rapid`. The state machine in `set_test.go` validates invariants across all set implementations. Tests run in parallel.

--- a/examples_test.go
+++ b/examples_test.go
@@ -312,6 +312,10 @@ func ExampleContainsSeq() {
 	ints.Add(3)
 	ints.Add(2)
 
+	if ContainsSeq(ints, slices.Values([]int{})) {
+		fmt.Println("Non-empty set contains empty sequence")
+	}
+
 	if ContainsSeq(ints, slices.Values([]int{3, 5})) {
 		fmt.Println("3 and 5 are present")
 	}
@@ -321,6 +325,7 @@ func ExampleContainsSeq() {
 	}
 	// Output:
 	// Empty set contains empty sequence
+	// Non-empty set contains empty sequence
 	// 3 and 5 are present
 	// 6 is not present
 }

--- a/map.go
+++ b/map.go
@@ -59,7 +59,7 @@ func (s *Map[M]) Clear() int {
 
 // Add an element to the set. Returns true if the element was added, false if it was already present.
 func (s *Map[M]) Add(m M) bool {
-	if s.Contains(m) {
+	if _, ok := s.set[m]; ok {
 		return false
 	}
 	s.set[m] = struct{}{}
@@ -68,7 +68,7 @@ func (s *Map[M]) Add(m M) bool {
 
 // Remove an element from the set. Returns true if the element was removed, false if it was not present.
 func (s *Map[M]) Remove(m M) bool {
-	if !s.Contains(m) {
+	if _, ok := s.set[m]; !ok {
 		return false
 	}
 	delete(s.set, m)

--- a/set.go
+++ b/set.go
@@ -145,19 +145,17 @@ func Equal[K comparable](a, b Set[K]) bool {
 	if a.Cardinality() != b.Cardinality() {
 		return false
 	}
-	return Subset(a, b) && Subset(b, a)
+	return Subset(a, b)
 }
 
-// ContainsSeq returns true if the set contains all elements in the sequence. Empty sets are considered to contain only empty sequences.
+// ContainsSeq returns true if the set contains all elements in the sequence. Returns true for an empty sequence (vacuous truth).
 func ContainsSeq[K comparable](s Set[K], seq iter.Seq[K]) bool {
-	noitems := true
 	for k := range seq {
-		noitems = false
 		if !s.Contains(k) {
 			return false
 		}
 	}
-	return (s.Cardinality() == 0 && noitems) || !noitems
+	return true
 }
 
 // Disjoint returns true if the two sets have no elements in common.

--- a/set.go
+++ b/set.go
@@ -145,7 +145,12 @@ func Equal[K comparable](a, b Set[K]) bool {
 	if a.Cardinality() != b.Cardinality() {
 		return false
 	}
-	return Subset(a, b)
+	for k := range a.Iterator {
+		if !b.Contains(k) {
+			return false
+		}
+	}
+	return true
 }
 
 // ContainsSeq returns true if the set contains all elements in the sequence. Returns true for an empty sequence (vacuous truth).


### PR DESCRIPTION
## Summary

- **`Equal` optimization**: Remove redundant `Subset(b, a)` call — when cardinalities are verified equal, a single `Subset(a, b)` check is sufficient to prove set equality
- **`Map.Add`/`Remove` optimization**: Inline map key lookup (`_, ok := s.set[m]`) instead of calling the `Contains` method, eliminating a redundant method call per operation
- **`ContainsSeq` vacuous truth**: Return `true` for empty sequences, matching mathematical convention (universal quantification over an empty domain is vacuously true) and consistent with `ContainsAll()` behavior
- **`CLAUDE.md` conventions**: Document project patterns (zero-value style, tests-as-spec, mathematical correctness, conventional commits)

## Test plan

- [x] All existing tests pass with `-race`
- [x] No gopls diagnostics
- [x] `ContainsSeq` behavior now consistent with `ContainsAll` for empty input

🤖 Generated with [Claude Code](https://claude.com/claude-code)