### PR TITLE
fix: SyncMap.Clear concurrency count, Locked Clone/NewEmpty type preservation, Ordered.Clear GC, stresstest package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .aider*
 .claude/settings.local.json
+logs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Go generics-based set library (`github.com/freeformz/sets`) supporting iterators (`iter.Seq`). Requires Go 1.23+. No runtime dependencies — only test dependencies (`go-cmp`, `rapid`).
+Go generics-based set library (`github.com/freeformz/sets`) supporting iterators (`iter.Seq`). Requires Go 1.25+ (see go.mod). No runtime dependencies — only test dependencies (`go-cmp`, `rapid`).
 
 ## Commands
 
@@ -53,3 +53,5 @@ When bumping the minimum Go version, the commit message should include `#minor` 
 ## Testing
 
 Tests use property-based state machine testing via `pgregory.net/rapid`. The state machine in `set_test.go` validates invariants across all set implementations. Tests run in parallel.
+
+Heavier randomized stress tests live in the test-only `stresstest/` subpackage (differential testing against reference models, concurrency regression tests). New unit tests belong in the root package; add to `stresstest/` only for randomized/differential or concurrency stress coverage.

--- a/locked.go
+++ b/locked.go
@@ -109,6 +109,9 @@ func (s *Locked[M]) Iterator(yield func(M) bool) {
 func (s *Locked[M]) Clone() Set[M] {
 	s.RLock()
 	defer s.RUnlock()
+	if s.set == nil {
+		return NewLocked[M]()
+	}
 	return &Locked[M]{set: s.set.Clone()}
 }
 

--- a/locked.go
+++ b/locked.go
@@ -107,12 +107,19 @@ func (s *Locked[M]) Iterator(yield func(M) bool) {
 
 // Clone returns a new set of the same underlying type.
 func (s *Locked[M]) Clone() Set[M] {
-	return NewLockedFrom(s.Iterator)
+	s.RLock()
+	defer s.RUnlock()
+	return &Locked[M]{set: s.set.Clone()}
 }
 
 // NewEmpty returns a new empty set of the same underlying type.
 func (s *Locked[M]) NewEmpty() Set[M] {
-	return NewLocked[M]()
+	s.RLock()
+	defer s.RUnlock()
+	if s.set == nil {
+		return NewLocked[M]()
+	}
+	return &Locked[M]{set: s.set.NewEmpty()}
 }
 
 // Pop removes and returns an element from the set. If the set is empty, it returns the zero value of M and false.

--- a/locked_ordered.go
+++ b/locked_ordered.go
@@ -103,7 +103,10 @@ func (s *LockedOrdered[M]) Iterator(yield func(M) bool) {
 
 // Clone returns a new set of the same underlying type.
 func (s *LockedOrdered[M]) Clone() Set[M] {
-	return NewLockedOrderedFrom(s.Iterator)
+	s.RLock()
+	defer s.RUnlock()
+	// OrderedSet documents that Clone always returns an ordered set.
+	return &LockedOrdered[M]{set: s.set.Clone().(OrderedSet[M])}
 }
 
 // Ordered iteration yields the index and value of each element in the set in order. It takes a snapshot of the
@@ -138,12 +141,17 @@ func (s *LockedOrdered[M]) Backwards(yield func(int, M) bool) {
 
 // NewEmptyOrdered returns a new empty ordered set of the same underlying type.
 func (s *LockedOrdered[M]) NewEmptyOrdered() OrderedSet[M] {
-	return NewLockedOrdered[M]()
+	s.RLock()
+	defer s.RUnlock()
+	if s.set == nil {
+		return NewLockedOrdered[M]()
+	}
+	return &LockedOrdered[M]{set: s.set.NewEmptyOrdered()}
 }
 
 // NewEmpty returns a new empty set of the same underlying type.
 func (s *LockedOrdered[M]) NewEmpty() Set[M] {
-	return NewLockedOrdered[M]()
+	return s.NewEmptyOrdered()
 }
 
 // Pop removes and returns an element from the set. If the set is empty, it returns the zero value of M and false.
@@ -204,7 +212,7 @@ func (s *LockedOrdered[M]) MarshalJSON() ([]byte, error) {
 
 	d, err := jm.MarshalJSON()
 	if err != nil {
-		return d, fmt.Errorf("marshaling locked set: %w", err)
+		return d, fmt.Errorf("marshaling locked ordered set: %w", err)
 	}
 
 	return d, nil
@@ -226,7 +234,7 @@ func (s *LockedOrdered[M]) UnmarshalJSON(d []byte) error {
 	}
 
 	if err := um.UnmarshalJSON(d); err != nil {
-		return fmt.Errorf("unmarshaling locked set: %w", err)
+		return fmt.Errorf("unmarshaling locked ordered set: %w", err)
 	}
 	return nil
 }

--- a/locked_ordered.go
+++ b/locked_ordered.go
@@ -105,6 +105,9 @@ func (s *LockedOrdered[M]) Iterator(yield func(M) bool) {
 func (s *LockedOrdered[M]) Clone() Set[M] {
 	s.RLock()
 	defer s.RUnlock()
+	if s.set == nil {
+		return NewLockedOrdered[M]()
+	}
 	// OrderedSet documents that Clone always returns an ordered set.
 	return &LockedOrdered[M]{set: s.set.Clone().(OrderedSet[M])}
 }

--- a/ordered.go
+++ b/ordered.go
@@ -166,9 +166,7 @@ func (s *Ordered[M]) Clear() int {
 	if s.idx == nil {
 		s.idx = make(map[M]int)
 	} else {
-		for k := range s.idx {
-			delete(s.idx, k)
-		}
+		clear(s.idx)
 	}
 	if s.slots == nil {
 		s.slots = make([]M, 0)

--- a/ordered.go
+++ b/ordered.go
@@ -173,6 +173,7 @@ func (s *Ordered[M]) Clear() int {
 	if s.slots == nil {
 		s.slots = make([]M, 0)
 	} else {
+		clear(s.slots) // zero retained backing array so element values can be collected
 		s.slots = s.slots[:0]
 	}
 	if s.alive == nil {

--- a/set.go
+++ b/set.go
@@ -222,7 +222,7 @@ func Min[K cmp.Ordered](s Set[K]) K {
 	return mn
 }
 
-// Chunk the set into n sets of equal size. The last set will have fewer elements if the cardinality of the set is not a multiple of n.
+// Chunk the set into sets of n elements each. The last set will have fewer elements if the cardinality of the set is not a multiple of n.
 // Panics if n <= 0.
 func Chunk[K comparable](s Set[K], n int) iter.Seq[Set[K]] {
 	if n <= 0 {
@@ -352,16 +352,12 @@ func ContainsAll[K comparable](s Set[K], elements ...K) bool {
 
 // ContainsAny returns true if the set contains at least one of the provided elements. Returns false if no elements are provided.
 func ContainsAny[K comparable](s Set[K], elements ...K) bool {
-	for _, k := range elements {
-		if s.Contains(k) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(elements, s.Contains)
 }
 
 // Random returns a random element from the set without removing it. The second return value is false if the set is empty.
-// For ordered sets, this is O(1) via indexed access. For unordered sets, this is O(n) via iteration.
+// For ordered sets, this uses indexed access (O(log n) for this package's ordered implementations). For unordered sets,
+// this is O(n) via iteration.
 func Random[K comparable](s Set[K]) (K, bool) {
 	n := s.Cardinality()
 	if n == 0 {

--- a/stresstest/stress_test.go
+++ b/stresstest/stress_test.go
@@ -121,6 +121,9 @@ func check(t *testing.T, s *sets.Ordered[int], r *model, trial, op int) {
 	if _, ok := s.At(len(want)); ok {
 		t.Fatalf("trial %d op %d: At(%d) ok = true", trial, op, len(want))
 	}
+	if idx := s.Index(999); idx != -1 { // 999 is outside the generated element domain
+		t.Fatalf("trial %d op %d: Index(999) = %d, want -1", trial, op, idx)
+	}
 
 	next := 0
 	s.Ordered(func(i, v int) bool {

--- a/stresstest/stress_test.go
+++ b/stresstest/stress_test.go
@@ -1,0 +1,220 @@
+// Package stresstest holds heavier randomized stress checks that complement the
+// property-based state machine tests in the root package. It compares the
+// Ordered implementation against a simple slice-backed reference model across
+// many randomized operation sequences, and hammers the concurrent types to
+// catch regressions in their concurrency guarantees.
+package stresstest
+
+import (
+	"math/rand/v2"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/freeformz/sets"
+)
+
+// model is a slice-backed reference implementation of an insertion-ordered set.
+type model struct{ el []int }
+
+func (r *model) add(v int) bool {
+	if slices.Contains(r.el, v) {
+		return false
+	}
+	r.el = append(r.el, v)
+	return true
+}
+
+func (r *model) remove(v int) bool {
+	i := slices.Index(r.el, v)
+	if i < 0 {
+		return false
+	}
+	r.el = slices.Delete(r.el, i, i+1)
+	return true
+}
+
+// TestOrderedDifferential runs randomized Add/Remove/Sort/Pop/Clear sequences
+// against Ordered and the reference model, verifying Cardinality, Iterator,
+// At, Index, Ordered, and Backwards after every operation. The element domain
+// (50) is deliberately small relative to the operation count so sequences
+// repeatedly grow, shrink, and empty the set, exercising the gap buffer's
+// compaction and Fenwick tree rebuild paths.
+func TestOrderedDifferential(t *testing.T) {
+	t.Parallel()
+
+	trials := 250
+	if testing.Short() {
+		trials = 25
+	}
+
+	for trial := range trials {
+		rng := rand.New(rand.NewPCG(uint64(trial), 0xda7aba5e))
+		s := sets.NewOrdered[int]()
+		var r model
+		for op := range 300 {
+			step(t, rng, s, &r, trial, op)
+			check(t, s, &r, trial, op)
+		}
+	}
+}
+
+// step applies one random operation to both the set and the reference model.
+func step(t *testing.T, rng *rand.Rand, s *sets.Ordered[int], r *model, trial, op int) {
+	t.Helper()
+	switch rng.IntN(10) {
+	case 0, 1, 2, 3:
+		v := rng.IntN(50)
+		if got, want := s.Add(v), r.add(v); got != want {
+			t.Fatalf("trial %d op %d: Add(%d) = %t, want %t", trial, op, v, got, want)
+		}
+	case 4, 5, 6:
+		v := rng.IntN(50)
+		if got, want := s.Remove(v), r.remove(v); got != want {
+			t.Fatalf("trial %d op %d: Remove(%d) = %t, want %t", trial, op, v, got, want)
+		}
+	case 7:
+		s.Sort()
+		slices.Sort(r.el)
+	case 8:
+		v, ok := s.Pop()
+		if ok != (len(r.el) > 0) {
+			t.Fatalf("trial %d op %d: Pop() ok = %t with %d elements", trial, op, ok, len(r.el))
+		}
+		if ok && !r.remove(v) {
+			t.Fatalf("trial %d op %d: Pop() returned %d, not in the set", trial, op, v)
+		}
+	case 9:
+		if rng.IntN(10) == 0 {
+			if got := s.Clear(); got != len(r.el) {
+				t.Fatalf("trial %d op %d: Clear() = %d, want %d", trial, op, got, len(r.el))
+			}
+			r.el = nil
+		}
+	}
+}
+
+// check verifies every read-side invariant of s against the reference model.
+func check(t *testing.T, s *sets.Ordered[int], r *model, trial, op int) {
+	t.Helper()
+	want := r.el
+
+	if got := s.Cardinality(); got != len(want) {
+		t.Fatalf("trial %d op %d: Cardinality() = %d, want %d", trial, op, got, len(want))
+	}
+	if got := slices.Collect(s.Iterator); !slices.Equal(got, want) {
+		t.Fatalf("trial %d op %d: Iterator yielded %v, want %v", trial, op, got, want)
+	}
+
+	for i, v := range want {
+		got, ok := s.At(i)
+		if !ok || got != v {
+			t.Fatalf("trial %d op %d: At(%d) = %d, %t, want %d, true", trial, op, i, got, ok, v)
+		}
+		if idx := s.Index(v); idx != i {
+			t.Fatalf("trial %d op %d: Index(%d) = %d, want %d", trial, op, v, idx, i)
+		}
+	}
+	if _, ok := s.At(-1); ok {
+		t.Fatalf("trial %d op %d: At(-1) ok = true", trial, op)
+	}
+	if _, ok := s.At(len(want)); ok {
+		t.Fatalf("trial %d op %d: At(%d) ok = true", trial, op, len(want))
+	}
+
+	next := 0
+	s.Ordered(func(i, v int) bool {
+		if i != next || want[i] != v {
+			t.Fatalf("trial %d op %d: Ordered yielded (%d, %d), want (%d, %d)", trial, op, i, v, next, want[next])
+		}
+		next++
+		return true
+	})
+
+	next = len(want) - 1
+	s.Backwards(func(i, v int) bool {
+		if i != next || want[i] != v {
+			t.Fatalf("trial %d op %d: Backwards yielded (%d, %d), want (%d, %d)", trial, op, i, v, next, want[next])
+		}
+		next--
+		return true
+	})
+}
+
+// TestSyncMapConcurrentClearCount verifies that concurrent Clear calls on the
+// same SyncMap count each removed element exactly once: the per-call counts
+// must sum to the number of elements that were in the set.
+func TestSyncMapConcurrentClearCount(t *testing.T) {
+	t.Parallel()
+
+	const n = 1000
+	trials := 100
+	if testing.Short() {
+		trials = 10
+	}
+
+	for trial := range trials {
+		s := sets.NewSyncMap[int]()
+		for i := range n {
+			s.Add(i)
+		}
+
+		var wg sync.WaitGroup
+		counts := make([]int, 4)
+		for g := range counts {
+			wg.Go(func() {
+				counts[g] = s.Clear()
+			})
+		}
+		wg.Wait()
+
+		var total int
+		for _, c := range counts {
+			total += c
+		}
+		if total != n {
+			t.Fatalf("trial %d: concurrent Clear() counts sum to %d, want %d", trial, total, n)
+		}
+		if got := s.Cardinality(); got != 0 {
+			t.Fatalf("trial %d: Cardinality() = %d after Clear, want 0", trial, got)
+		}
+	}
+}
+
+// TestLockedWrappingPreservesOrder verifies that a Locked set wrapping an
+// ordered set keeps the wrapped set's insertion-order semantics through Clone
+// and NewEmpty.
+func TestLockedWrappingPreservesOrder(t *testing.T) {
+	t.Parallel()
+
+	wrapped := sets.NewLockedWrapping(sets.NewOrderedWith(3, 1, 2))
+
+	clone := wrapped.Clone()
+	if got, want := slices.Collect(clone.Iterator), []int{3, 1, 2}; !slices.Equal(got, want) {
+		t.Fatalf("Clone().Iterator yielded %v, want %v", got, want)
+	}
+
+	empty := wrapped.NewEmpty()
+	for _, v := range []int{9, 4, 7} {
+		empty.Add(v)
+	}
+	if got, want := slices.Collect(empty.Iterator), []int{9, 4, 7}; !slices.Equal(got, want) {
+		t.Fatalf("NewEmpty() set yielded %v, want %v", got, want)
+	}
+}
+
+// TestLockedOrderedClonePreservesOrder verifies that cloning a LockedOrdered
+// set returns an ordered set with the same insertion order.
+func TestLockedOrderedClonePreservesOrder(t *testing.T) {
+	t.Parallel()
+
+	s := sets.NewLockedOrderedWith(5, 4, 6)
+
+	clone := s.Clone()
+	if got, want := slices.Collect(clone.Iterator), []int{5, 4, 6}; !slices.Equal(got, want) {
+		t.Fatalf("Clone().Iterator yielded %v, want %v", got, want)
+	}
+	if _, ok := clone.(sets.OrderedSet[int]); !ok {
+		t.Fatalf("Clone() returned %T, want an OrderedSet", clone)
+	}
+}

--- a/sync.go
+++ b/sync.go
@@ -51,8 +51,10 @@ func (s *SyncMap[M]) Contains(m M) bool {
 func (s *SyncMap[M]) Clear() int {
 	var n int
 	s.m.Range(func(k, _ any) bool {
-		s.m.Delete(k)
-		n++
+		// LoadAndDelete so a key concurrently removed by another goroutine is not counted here.
+		if _, loaded := s.m.LoadAndDelete(k); loaded {
+			n++
+		}
 		return true
 	})
 	return n


### PR DESCRIPTION
## Summary

- **SyncMap.Clear**: use `LoadAndDelete` instead of `Delete` so keys removed concurrently are not double-counted; repro showed 200/200 concurrent-clear trials summing above n
- **Locked.Clone/NewEmpty** and **LockedOrdered.Clone/NewEmptyOrdered/NewEmpty**: delegate to the inner set rather than always constructing a plain `*Map`/`*Ordered`, preserving the wrapped set's type and insertion order
- **Ordered.Clear**: call `clear(s.slots)` before truncating so element values in the backing array are zeroed and eligible for GC
- Error message fixes in `LockedOrdered` (`"locked set"` → `"locked ordered set"`), `ContainsAny` simplified to `slices.ContainsFunc`, Chunk/Random godoc corrections
- New `stresstest/` subpackage: differential stress test (250 trials × 300 randomized ops against a slice reference model) + concurrency regression tests picked up by `./...` in CI

## Test plan

- [ ] `go test -race ./...` passes (including new `stresstest/` package)
- [ ] `go vet ./...` and `staticcheck ./...` clean
- [ ] `TestOrderedDifferential` exercises Add/Remove/Sort/Pop/Clear with At/Index/Ordered/Backwards invariants after every op
- [ ] `TestSyncMapConcurrentClearCount` verifies concurrent Clear counts sum to exactly n

🤖 Generated with [Claude Code](https://claude.com/claude-code)