### PR TITLE
fix(ci): publish GitHub Releases from the version-bump workflow #none

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,8 +19,19 @@ jobs:
         fetch-depth: '0'
 
     - name: Bump version and push tag
+      id: tag_version
       uses: anothrNick/github-tag-action@v1 # Don't use @master or @v1 unless you're happy to test the latest version
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true
         DEFAULT_BUMP: patch
+
+    - name: Create GitHub release
+      if: steps.tag_version.outputs.new_tag != ''
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh release create "${{ steps.tag_version.outputs.new_tag }}" \
+          --repo "${{ github.repository }}" \
+          --title "${{ steps.tag_version.outputs.new_tag }}" \
+          --generate-notes

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Bump version and push tag
       id: tag_version
-      uses: anothrNick/github-tag-action@v1 # Don't use @master or @v1 unless you're happy to test the latest version
+      uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8 # v1.75.0 — pinned to a commit SHA to avoid trusting a floating tag
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,14 +41,30 @@ All types implement `json.Marshaler`/`json.Unmarshaler` and `sql.Scanner`. The `
 
 ## Versioning
 
-When bumping the minimum Go version, the commit message should include `#minor` to trigger a minor version bump.
+Releases are fully automated by `.github/workflows/release.yaml` ("Bump version"), which runs on every PR merge to `main`:
+
+1. `anothrNick/github-tag-action` computes the next semver tag and pushes it (`v`-prefixed).
+2. A `gh release create --generate-notes` step publishes a matching GitHub Release.
+
+**This repo squash-merges PRs** (`allow_merge_commit: false`), so each merge produces exactly one commit on `main`. The tag action scans that squash commit's *entire* message — subject (the PR title, unless edited at merge time) plus body (which, by GitHub's default squash template, is the concatenated list of every individual commit message in the PR) — for bump tokens. Placing a token in **either** the PR title or any commit message in the branch works.
+
+**Bump rules** (`DEFAULT_BUMP: patch` is configured in the workflow, overriding the action's own default of `minor`):
+
+| Token (anywhere in the PR title or a commit message) | Result |
+|---|---|
+| *(none)* | patch bump — the default for ordinary fixes |
+| `#minor` | minor bump — required for new backwards-compatible functionality, and for bumping the minimum Go version |
+| `#major` | major bump — breaking API changes |
+| `#none` | no tag/release is created for this merge — use for docs/chore/CI-only changes that shouldn't cut a release |
+
+Match the token to the PR's overall scope, not to every individual commit inside it — a PR mixing a `feat:` with incidental `fix:`/`test:` commits still only needs one `#minor` somewhere for the whole merge to bump minor.
 
 ## Conventions
 
 - **Zero-value style**: Use `var x T` instead of `x := T{}`; refer to this as "T's zero value" in prose.
 - **Tests are the spec**: When modifying implementations, do not change tests. Treat test failures as implementation bugs.
 - **Mathematical correctness**: Prefer mathematically correct semantics (e.g., vacuous truth for empty predicates).
-- **Commit messages**: Use conventional commits (`feat:`, `fix:`, `docs:`, etc.).
+- **Commit messages**: Use conventional commits (`feat:`, `fix:`, `docs:`, etc.). See [Versioning](#versioning) for the bump-token convention (`#minor`/`#major`/`#none`) that controls what release a PR produces.
 
 ## Testing
 

--- a/README.MD
+++ b/README.MD
@@ -6,8 +6,6 @@
 
 A generics based go set package that supports modern go features like iterators.
 
-NOTE: This is currently a WIP. I don't expect to make any breaking API changes atm, but am not able to rule it out yet.
-
 If you like this repo, please consider checking out my [iterator tools repo](https://github.com/freeformz/seq).
 
 ## Install


### PR DESCRIPTION
## Summary

The `release.yaml` "Bump version" workflow only pushed a git tag via `anothrNick/github-tag-action`; it never created a GitHub Release. Tags kept advancing on every merge to `main`, but the Releases page stayed empty.

Adds a step that publishes a GitHub Release for the newly pushed tag, with `--generate-notes` to auto-summarize the merged PRs since the previous release.

Also removes the stale WIP disclaimer from the README, and documents the release workflow's version-bump token convention in CLAUDE.md (see that file for the full table).

This PR is CI/docs-only — it doesn't change the `sets` package's public API, so it carries `#none` in the title to skip cutting a tag/release for this merge (per the convention it itself documents).

## Test plan

- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yaml'))"`)
- [ ] Next PR merge to `main` that *does* warrant a release produces both a new tag and a corresponding GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)