### PR TITLE
docs: warn against writing version-bump tokens in commit prose #none

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,8 @@ Releases are fully automated by `.github/workflows/release.yaml` ("Bump version"
 
 Match the token to the PR's overall scope, not to every individual commit inside it — a PR mixing a `feat:` with incidental `fix:`/`test:` commits still only needs one `#minor` somewhere for the whole merge to bump minor.
 
+**Landmine**: the scanner does a plain substring match over the full squashed commit text — it has no idea a token appears inside prose rather than as a directive. Never write the literal, hash-prefixed tokens together in a commit message body when merely describing the convention (e.g. "supports #major/#minor/#patch/#none") — an incidental `#major` substring there will out-rank real `#none`/`#minor` tags elsewhere in the same PR and trigger an unintended major release (this happened once: PR #33's docs commit describing this exact convention accidentally cut `v1.0.0` from a `v0.12.0` base). When discussing the tokens in a commit message, drop the `#` prefix (`major`/`minor`/`patch`/`none`) or reference this file instead. The tokens are safe to write in full inside file content (e.g. this doc) — only commit *messages* are scanned, not diffs.
+
 ## Conventions
 
 - **Zero-value style**: Use `var x T` instead of `x := T{}`; refer to this as "T's zero value" in prose.


### PR DESCRIPTION
## Summary

Documents a landmine in the release automation: `anothrNick/github-tag-action` does a plain substring match over the full squashed commit message for major/minor/patch/none bump tokens. Writing the hash-prefixed tokens together in prose to *describe* the convention — rather than to *direct* a specific bump — can accidentally trigger one.

This isn't hypothetical: it happened in #33. That PR's docs commit described the convention by spelling out all three "minor", "major", and "none" tokens with their hash prefixes in one sentence, and the major token in that prose out-ranked the none token placed elsewhere in the same squash commit, cutting an unintended v1.0.0 from a v0.12.0 base. (The bad tag/release were deleted by hand; v0.12.1 was tagged manually to recover.)

Docs-only change, so it carries `#none` in the title. Note this repo's squash-merge template is `COMMIT_MESSAGES` (confirmed via `gh api repos/freeformz/sets --jq '.squash_merge_commit_message'`), so only commit messages — not this PR description — feed the scanner; this description still avoids writing the tokens together with their hash prefixes, on principle.

## Test plan

- [x] `git show -s --format='%B' <commit> | grep -oE '#[a-z]+'` on the new commit returns only `#none`
- [ ] This PR's merge does not cut a spurious tag/release

🤖 Generated with [Claude Code](https://claude.com/claude-code)