### PR TITLE
ci: make the Claude Code workflows functional (toolchain + comment permissions) #none

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write # required to post review comments on the PR
+      issues: write # required to post the review summary comment
       id-token: write
 
     steps:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -60,5 +60,5 @@ jobs:
           # Allow Claude to run the project's verification commands non-interactively.
           # go.mod requires Go 1.25+; the toolchain and staticcheck are installed in the
           # steps above. See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          claude_args: '--allowedTools "Bash(go:*),Bash(staticcheck:*),Bash(gofmt:*)"'
+          claude_args: '--allowedTools "Bash(go test:*),Bash(go vet:*),Bash(go build:*),Bash(go env:*),Bash(go version:*),Bash(staticcheck:*),Bash(gofmt:*)"'
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,6 +30,20 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Install the Go toolchain (pinned via go.mod) so Claude can build, vet,
+      # and run the race-enabled test suite when asked to verify changes.
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # Pre-install staticcheck and put $GOPATH/bin on PATH so it resolves in the
+      # Claude step below. Mirrors the linters CI runs (see ci.yaml).
+      - name: Install lint tools
+        run: |
+          go install honnef.co/go/tools/cmd/staticcheck@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
@@ -43,8 +57,8 @@ jobs:
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr *)'
+          # Allow Claude to run the project's verification commands non-interactively.
+          # go.mod requires Go 1.25+; the toolchain and staticcheck are installed in the
+          # steps above. See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          claude_args: '--allowedTools "Bash(go:*),Bash(staticcheck:*),Bash(gofmt:*)"'
 


### PR DESCRIPTION
CI-only changes to make both Claude Code workflows actually functional — tagged `#none` so it cuts no release.

## 1. `@claude` workflow (`claude.yml`) couldn't run verification commands

On #35 the `@claude` bot reported it could not run `go test -race ./...`, `go vet ./...`, or `staticcheck`:

> I wasn't able to run `go test -race ./...`, `go vet ./...`, or staticcheck in this environment (no permission to execute shell commands) … the `--allowedTools` for Bash would need to be widened for this job.

Two things were missing:

1. **No Go toolchain.** The job never ran `setup-go`, so `go` was either absent or older than the `go 1.25` / `toolchain go1.26.0` this module requires.
2. **No Bash allowlist.** With no `claude_args`, shell commands require interactive approval, which is always denied in a non-interactive Actions run.

Changes:
- Add `actions/setup-go@v5` pinned via `go-version-file: go.mod` (gives cgo for `-race` too).
- Pre-install `staticcheck` and add `$GOPATH/bin` to `PATH` — mirroring what `ci.yaml` runs.
- Set `claude_args` to allow the verification commands. Scoped to specific `go` subcommands (`test`, `vet`, `build`, `env`, `version`) plus `staticcheck` and `gofmt` — narrowed from an initial blanket `Bash(go:*)` per Copilot Autofix, so `go install`/`go get` and other file-mutating subcommands stay out.

## 2. Review workflow (`claude-code-review.yml`) ran but posted nothing

The automated `/code-review` on PR open was completing successfully but never commenting. The run log shows why: its `GITHUB_TOKEN` was granted only read scopes (`Contents: read`, `Issues: read`, `PullRequests: read`), so every attempt to write comments was denied — the run ended with `permission_denials_count: 10` and `No buffered inline comments`. The code-review plugin posts inline comments through the workflow token, so it needs write access.

Change:
- `pull-requests: read` → `write` (post review comments) and `issues: read` → `write` (post the summary comment). `contents` stays `read` — it doesn't push commits.

## Notes

- `@claude` (mention-triggered) posts its tracking comment as the Claude GitHub App, which is why it commented on #35 despite read-only token scopes; the review plugin's inline comments go through the workflow token, hence the different fix.
- Neither workflow is granted `contents: write`. If you later want a bot to push fixes directly, that's a separate, larger decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
