### PR TITLE
feat: add SortedSet, an always-sorted OrderedSet implementation #minor

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,9 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # Surface the full Claude transcript in the Actions log so a run that posts
+          # no comments can be diagnosed (found nothing vs. a blocked tool call).
+          show_full_output: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ CI runs checks (staticcheck, vet) on Ubuntu and tests (with `-race`) across Ubun
 - `SyncMap[M]` (`sync.go`) — `sync.Map`-based, concurrent-safe via `NewSyncMap()`
 - `Locked[M]` (`locked.go`) — RWMutex wrapper around a Set via `NewLocked()`
 - `Ordered[M]` (`ordered.go`) — insertion-ordered set via `NewOrdered()`
+- `SortedSet[M]` (`sorted.go`) — always-sorted set backed by a sorted slice via `NewSortedSet()`; read-optimized (O(log n) Contains, O(1) At, `Range(lo, hi)` queries), O(n) Add/Remove
 - `LockedOrdered[M]` (`locked_ordered.go`) — RWMutex wrapper around OrderedSet via `NewLockedOrdered()`
 
 **Design philosophy**: Functionality lives in package-level generic functions (in `set.go` and `ordered_set.go`), not methods. This aligns with stdlib `slices`/`maps` style. Locked types use composition, wrapping an inner set with mutex protection.

--- a/README.MD
+++ b/README.MD
@@ -26,7 +26,8 @@ go get github.com/freeformz/sets
   * `NewLocked()` -> Map based that uses a lock to be concurrency safe;
   * `NewSyncMap()` -> sync.Map based (concurrency safe);
   * `NewOrdered()` -> ordered set (uses a map for indexes and a slice for order);
-  * `NewLockedOrdered()` -> ordered set that is concurrency safe.
+  * `NewLockedOrdered()` -> ordered set that is concurrency safe;
+  * `NewSortedSet()` -> always sorted set backed by a single sorted slice. O(log n) `Contains`, O(1) `At`, range queries via `Range(lo, hi)`, and lower memory use, at the cost of O(n) `Add`/`Remove`. Best for read-heavy workloads. Wrap with `NewLockedOrderedWrapping()` to make it concurrency safe.
 * `sets` package functions align with standard lib packages like `slices` and `maps`.
 * Implement as much as possible as package functions, not Set methods.
 * Exhaustive unit tests via [rapid](https://github.com/flyingmutant/rapid).
@@ -102,7 +103,7 @@ These helpers work on all OrderedSet types.
 
 ## Benchmarks
 
-Benchmarks cover all 5 set implementations (`Map`, `SyncMap`, `Locked`, `Ordered`, `LockedOrdered`) with both `int` and `string` element types at sizes from 10 to 1,000,000.
+Benchmarks cover all 6 set implementations (`Map`, `SyncMap`, `Locked`, `Ordered`, `SortedSet`, `LockedOrdered`) with both `int` and `string` element types at sizes from 10 to 1,000,000.
 
 ### Running Benchmarks
 

--- a/README.MD
+++ b/README.MD
@@ -27,7 +27,7 @@ go get github.com/freeformz/sets
   * `NewSyncMap()` -> sync.Map based (concurrency safe);
   * `NewOrdered()` -> ordered set (uses a map for indexes and a slice for order);
   * `NewLockedOrdered()` -> ordered set that is concurrency safe;
-  * `NewSortedSet()` -> always sorted set backed by a single sorted slice. O(log n) `Contains`, O(1) `At`, range queries via `Range(lo, hi)`, and lower memory use, at the cost of O(n) `Add`/`Remove`. Best for read-heavy workloads. Wrap with `NewLockedOrderedWrapping()` to make it concurrency safe.
+  * `NewSortedSet()` -> always sorted set backed by a single sorted slice. O(log n) `Contains`, O(1) `At`, range queries via `Range(lo, hi)`, and lower memory use, at the cost of O(n) `Add`/`Remove`. Best for read-heavy workloads. Wrap with `NewLockedOrderedWrapping(NewSortedSet[...]())` to make it concurrency safe.
 * `sets` package functions align with standard lib packages like `slices` and `maps`.
 * Implement as much as possible as package functions, not Set methods.
 * Exhaustive unit tests via [rapid](https://github.com/flyingmutant/rapid).

--- a/README.MD
+++ b/README.MD
@@ -27,7 +27,7 @@ go get github.com/freeformz/sets
   * `NewSyncMap()` -> sync.Map based (concurrency safe);
   * `NewOrdered()` -> ordered set (uses a map for indexes and a slice for order);
   * `NewLockedOrdered()` -> ordered set that is concurrency safe;
-  * `NewSortedSet()` -> always sorted set backed by a single sorted slice. O(log n) `Contains`, O(1) `At`, range queries via `Range(lo, hi)`, and lower memory use, at the cost of O(n) `Add`/`Remove`. Best for read-heavy workloads. Wrap with `NewLockedOrderedWrapping(NewSortedSet[...]())` to make it concurrency safe.
+  * `NewSortedSet()` -> always sorted set backed by a single sorted slice. O(log n) `Contains`, O(1) `At`, range queries via `Range(lo, hi)`, and lower memory use, at the cost of O(n) `Add`/`Remove`. Best for read-heavy workloads. Wrap with `NewLockedOrderedWrapping(NewSortedSet[int]())` to make it concurrency safe.
 * `sets` package functions align with standard lib packages like `slices` and `maps`.
 * Implement as much as possible as package functions, not Set methods.
 * Exhaustive unit tests via [rapid](https://github.com/flyingmutant/rapid).

--- a/bench_test.go
+++ b/bench_test.go
@@ -51,6 +51,7 @@ var benchImpls = []benchImpl{
 	{"SyncMap", func() Set[int] { return NewSyncMap[int]() }, func() Set[string] { return NewSyncMap[string]() }},
 	{"Locked", func() Set[int] { return NewLocked[int]() }, func() Set[string] { return NewLocked[string]() }},
 	{"Ordered", func() Set[int] { return NewOrdered[int]() }, func() Set[string] { return NewOrdered[string]() }},
+	{"SortedSet", func() Set[int] { return NewSortedSet[int]() }, func() Set[string] { return NewSortedSet[string]() }},
 	{"LockedOrdered", func() Set[int] { return NewLockedOrdered[int]() }, func() Set[string] { return NewLockedOrdered[string]() }},
 }
 

--- a/examples_test.go
+++ b/examples_test.go
@@ -940,3 +940,65 @@ func ExampleLast() {
 	// 1
 	// empty set
 }
+
+func ExampleNewSortedSet() {
+	set := NewSortedSet[string]()
+	set.Add("c")
+	set.Add("a")
+	set.Add("b")
+	set.Add("b")
+	fmt.Println(set.Cardinality())
+
+	for i := range set.Iterator {
+		fmt.Println(i)
+	}
+
+	// Output:
+	// 3
+	// a
+	// b
+	// c
+}
+
+func ExampleNewSortedSetWith() {
+	set := NewSortedSetWith("c", "a", "b", "b")
+	fmt.Println(set.Cardinality())
+
+	for i := range set.Iterator {
+		fmt.Println(i)
+	}
+
+	// Output:
+	// 3
+	// a
+	// b
+	// c
+}
+
+func ExampleNewSortedSetFrom() {
+	set := NewSortedSetFrom(slices.Values([]string{"c", "a", "b", "b"}))
+	fmt.Println(set.Cardinality())
+
+	for i := range set.Iterator {
+		fmt.Println(i)
+	}
+
+	// Output:
+	// 3
+	// a
+	// b
+	// c
+}
+
+func ExampleSortedSet_Range() {
+	set := NewSortedSetWith(50, 10, 40, 20, 30)
+
+	for v := range set.Range(15, 40) {
+		fmt.Println(v)
+	}
+
+	// Output:
+	// 20
+	// 30
+	// 40
+}

--- a/examples_test.go
+++ b/examples_test.go
@@ -964,8 +964,8 @@ func ExampleNewSortedSetWith() {
 	set := NewSortedSetWith("c", "a", "b", "b")
 	fmt.Println(set.Cardinality())
 
-	for i := range set.Iterator {
-		fmt.Println(i)
+	for v := range set.Iterator {
+		fmt.Println(v)
 	}
 
 	// Output:

--- a/examples_test.go
+++ b/examples_test.go
@@ -979,8 +979,8 @@ func ExampleNewSortedSetFrom() {
 	set := NewSortedSetFrom(slices.Values([]string{"c", "a", "b", "b"}))
 	fmt.Println(set.Cardinality())
 
-	for i := range set.Iterator {
-		fmt.Println(i)
+	for v := range set.Iterator {
+		fmt.Println(v)
 	}
 
 	// Output:

--- a/examples_test.go
+++ b/examples_test.go
@@ -949,8 +949,8 @@ func ExampleNewSortedSet() {
 	set.Add("b")
 	fmt.Println(set.Cardinality())
 
-	for i := range set.Iterator {
-		fmt.Println(i)
+	for v := range set.Iterator {
+		fmt.Println(v)
 	}
 
 	// Output:

--- a/sorted.go
+++ b/sorted.go
@@ -60,7 +60,7 @@ func (s *SortedSet[M]) Contains(m M) bool {
 	return ok
 }
 
-// Clear the set and returns the number of elements removed.
+// Clear clears the set and returns the number of elements removed.
 func (s *SortedSet[M]) Clear() int {
 	n := len(s.el)
 	clear(s.el) // zero the retained backing array so element values can be collected

--- a/sorted.go
+++ b/sorted.go
@@ -1,0 +1,233 @@
+package sets
+
+import (
+	"cmp"
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"iter"
+	"slices"
+)
+
+// SortedSet maintains its elements in ascending sorted order at all times. Unlike Ordered, which
+// preserves insertion order and can only be sorted transiently via Sort, the sorted order of a
+// SortedSet is an invariant that Add maintains. It is backed by a single sorted slice with no
+// companion map, so it uses less memory per element than the other implementations and iterates with
+// good cache locality. It is not safe for concurrent use; wrap it with NewLockedOrderedWrapping when
+// concurrency is needed.
+//
+// SortedSet's zero value is ready to use.
+//
+// Complexity:
+//   - Add: O(N) (O(log N) search + shift)
+//   - Remove: O(N) (O(log N) search + shift)
+//   - Contains: O(log N)
+//   - At: O(1)
+//   - Index: O(log N)
+//   - Iterator: O(N)
+//
+// The O(N) Add/Remove shifts make SortedSet best suited to read-heavy workloads (build once, query
+// many times). For add/remove-heavy workloads prefer Ordered or Map.
+type SortedSet[M cmp.Ordered] struct {
+	el []M // sorted ascending, no duplicates
+}
+
+var _ OrderedSet[int] = new(SortedSet[int])
+var _ driver.Valuer = new(SortedSet[int])
+
+// NewSortedSet returns an empty *SortedSet[M].
+func NewSortedSet[M cmp.Ordered]() *SortedSet[M] {
+	return &SortedSet[M]{el: make([]M, 0)}
+}
+
+// NewSortedSetFrom returns a new *SortedSet[M] filled with the values from the sequence.
+func NewSortedSetFrom[M cmp.Ordered](seq iter.Seq[M]) *SortedSet[M] {
+	// bulk sort + compact instead of adding element by element, which would pay an
+	// O(N) insertion shift per element
+	el := slices.Collect(seq)
+	slices.Sort(el)
+	return &SortedSet[M]{el: slices.Compact(el)}
+}
+
+// NewSortedSetWith returns a new *SortedSet[M] with the values provided.
+func NewSortedSetWith[M cmp.Ordered](m ...M) *SortedSet[M] {
+	return NewSortedSetFrom(slices.Values(m))
+}
+
+// Contains returns true if the set contains the element.
+func (s *SortedSet[M]) Contains(m M) bool {
+	_, ok := slices.BinarySearch(s.el, m)
+	return ok
+}
+
+// Clear the set and returns the number of elements removed.
+func (s *SortedSet[M]) Clear() int {
+	n := len(s.el)
+	clear(s.el) // zero the retained backing array so element values can be collected
+	s.el = s.el[:0]
+	return n
+}
+
+// Add an element to the set. Returns true if the element was added, false if it was already present.
+// The element is inserted at its sorted position.
+func (s *SortedSet[M]) Add(m M) bool {
+	i, ok := slices.BinarySearch(s.el, m)
+	if ok {
+		return false
+	}
+	s.el = slices.Insert(s.el, i, m)
+	return true
+}
+
+// Remove an element from the set. Returns true if the element was removed, false if it was not present.
+func (s *SortedSet[M]) Remove(m M) bool {
+	i, ok := slices.BinarySearch(s.el, m)
+	if !ok {
+		return false
+	}
+	s.el = slices.Delete(s.el, i, i+1)
+	return true
+}
+
+// Cardinality returns the number of elements in the set.
+func (s *SortedSet[M]) Cardinality() int {
+	if s == nil {
+		return 0
+	}
+	return len(s.el)
+}
+
+// Iterator yields all elements in the set in ascending order.
+func (s *SortedSet[M]) Iterator(yield func(M) bool) {
+	for _, v := range s.el {
+		if !yield(v) {
+			return
+		}
+	}
+}
+
+// Clone returns a copy of the set. The underlying type is the same as the original set.
+func (s *SortedSet[M]) Clone() Set[M] {
+	return &SortedSet[M]{el: slices.Clone(s.el)}
+}
+
+// Ordered iteration yields the index and value of each element in the set in ascending order.
+func (s *SortedSet[M]) Ordered(yield func(int, M) bool) {
+	for i, v := range s.el {
+		if !yield(i, v) {
+			return
+		}
+	}
+}
+
+// Backwards iteration yields the index and value of each element in the set in descending order.
+func (s *SortedSet[M]) Backwards(yield func(int, M) bool) {
+	for i := len(s.el) - 1; i >= 0; i-- {
+		if !yield(i, s.el[i]) {
+			return
+		}
+	}
+}
+
+// Range returns an iterator over the elements v for which lo <= v <= hi, in ascending order. The
+// endpoints are located by binary search, so a call costs O(log N) plus the number of elements
+// yielded. If lo > hi the iterator yields nothing.
+func (s *SortedSet[M]) Range(lo, hi M) iter.Seq[M] {
+	return func(yield func(M) bool) {
+		start, _ := slices.BinarySearch(s.el, lo)
+		for _, v := range s.el[start:] {
+			if cmp.Less(hi, v) || !yield(v) {
+				return
+			}
+		}
+	}
+}
+
+// NewEmptyOrdered returns a new empty ordered set of the same underlying type.
+func (s *SortedSet[M]) NewEmptyOrdered() OrderedSet[M] {
+	return NewSortedSet[M]()
+}
+
+// NewEmpty returns a new empty set of the same underlying type.
+func (s *SortedSet[M]) NewEmpty() Set[M] {
+	return NewSortedSet[M]()
+}
+
+// Pop removes and returns the largest element of the set. If the set is empty, it returns the zero
+// value of M and false. Removing from the end avoids the shift other removals pay, so Pop is O(1).
+func (s *SortedSet[M]) Pop() (M, bool) {
+	if len(s.el) == 0 {
+		var m M
+		return m, false
+	}
+	m := s.el[len(s.el)-1]
+	s.el = slices.Delete(s.el, len(s.el)-1, len(s.el))
+	return m, true
+}
+
+// Sort is a no-op: the set is always sorted in ascending order.
+func (s *SortedSet[M]) Sort() {}
+
+// At returns the element at the index. If the index is out of bounds, the second return value is false.
+func (s *SortedSet[M]) At(i int) (M, bool) {
+	if i < 0 || i >= len(s.el) {
+		var zero M
+		return zero, false
+	}
+	return s.el[i], true
+}
+
+// Index returns the index of the element in the set, or -1 if not present.
+func (s *SortedSet[M]) Index(m M) int {
+	i, ok := slices.BinarySearch(s.el, m)
+	if !ok {
+		return -1
+	}
+	return i
+}
+
+// String returns a string representation of the set. It returns a string of the form SortedSet[T](<elements>).
+func (s *SortedSet[M]) String() string {
+	var m M
+	return fmt.Sprintf("SortedSet[%T](%v)", m, s.el)
+}
+
+// Value implements the driver.Valuer interface. It returns the JSON representation of the set.
+func (s *SortedSet[M]) Value() (driver.Value, error) {
+	return s.MarshalJSON()
+}
+
+// MarshalJSON implements json.Marshaler. It will marshal the set into a JSON array of the elements in
+// the set in ascending order. If the set is empty an empty JSON array is returned.
+func (s *SortedSet[M]) MarshalJSON() ([]byte, error) {
+	if len(s.el) == 0 {
+		return []byte("[]"), nil
+	}
+
+	d, err := json.Marshal(s.el)
+	if err != nil {
+		return d, fmt.Errorf("marshaling sorted set: %w", err)
+	}
+	return d, nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler. It expects a JSON array of the elements in the set. The
+// elements do not need to be sorted or unique; the set sorts and de-duplicates them. If the JSON is
+// invalid, it returns an error and the set is left unchanged.
+func (s *SortedSet[M]) UnmarshalJSON(d []byte) error {
+	t := make([]M, 0)
+	if err := json.Unmarshal(d, &t); err != nil {
+		return fmt.Errorf("unmarshaling sorted set: %w", err)
+	}
+
+	slices.Sort(t)
+	s.el = slices.Compact(t)
+	return nil
+}
+
+// Scan implements the sql.Scanner interface. It scans the value from the database into the set. It expects a JSON array
+// of the elements in the set. If the JSON is invalid an error is returned. If the value is nil an empty set is
+// returned.
+func (s *SortedSet[M]) Scan(src any) error {
+	return scanValue[M](src, s.Clear, s.UnmarshalJSON)
+}

--- a/sorted.go
+++ b/sorted.go
@@ -130,7 +130,7 @@ func (s *SortedSet[M]) Backwards(yield func(int, M) bool) {
 }
 
 // Range returns an iterator over the elements v for which lo <= v <= hi, in ascending order. The
-// endpoints are located by binary search, so a call costs O(log N) plus the number of elements
+// lower bound is located by binary search, so a call costs O(log N) plus the number of elements
 // yielded. If lo > hi the iterator yields nothing.
 func (s *SortedSet[M]) Range(lo, hi M) iter.Seq[M] {
 	return func(yield func(M) bool) {

--- a/sorted_test.go
+++ b/sorted_test.go
@@ -1,0 +1,470 @@
+package sets
+
+import (
+	"encoding/json"
+	"math"
+	"slices"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+func TestSortedSet(t *testing.T) {
+	t.Parallel()
+
+	setStateMachine := &SetStateMachine{
+		set:    NewSortedSet[int](),
+		stateI: make(map[int]int),
+	}
+	rapid.Check(t, func(t *rapid.T) {
+		t.Repeat(rapid.StateMachineActions(setStateMachine))
+	})
+}
+
+// TestSortedSet_Invariant verifies that the sorted invariant (strictly ascending, no duplicates)
+// holds after every mutation, checked against a map-based model.
+func TestSortedSet_Invariant(t *testing.T) {
+	t.Parallel()
+
+	rapid.Check(t, func(t *rapid.T) {
+		s := NewSortedSet[int]()
+		model := make(map[int]struct{})
+
+		steps := rapid.IntRange(1, 200).Draw(t, "Steps")
+		for range steps {
+			switch rapid.IntRange(0, 3).Draw(t, "Op") {
+			case 0:
+				v := rapid.IntRange(-50, 50).Draw(t, "Add")
+				_, exists := model[v]
+				if s.Add(v) == exists {
+					t.Fatalf("Add(%d): expected added=%v", v, !exists)
+				}
+				model[v] = struct{}{}
+			case 1:
+				v := rapid.IntRange(-50, 50).Draw(t, "Remove")
+				_, exists := model[v]
+				if s.Remove(v) != exists {
+					t.Fatalf("Remove(%d): expected removed=%v", v, exists)
+				}
+				delete(model, v)
+			case 2:
+				v, ok := s.Pop()
+				if ok != (len(model) > 0) {
+					t.Fatalf("Pop(): expected ok=%v", len(model) > 0)
+				}
+				if ok {
+					if _, exists := model[v]; !exists {
+						t.Fatalf("Pop(): returned %d, not in the model", v)
+					}
+					delete(model, v)
+				}
+			case 3:
+				s.Sort() // no-op, must not disturb anything
+			}
+
+			if s.Cardinality() != len(model) {
+				t.Fatalf("Cardinality() = %d, want %d", s.Cardinality(), len(model))
+			}
+			if !IsSorted(s) {
+				t.Fatalf("set is not sorted: %v", Elements(s))
+			}
+			var prev int
+			for i, v := range s.Ordered {
+				if i > 0 && v <= prev {
+					t.Fatalf("elements not strictly ascending at index %d: %v", i, Elements(s))
+				}
+				prev = v
+				if _, exists := model[v]; !exists {
+					t.Fatalf("set contains %d, model does not", v)
+				}
+			}
+		}
+	})
+}
+
+func TestSortedSet_Order(t *testing.T) {
+	t.Parallel()
+
+	s := NewSortedSetWith(5, 3, 9, 1, 7, 3) // includes a duplicate
+	want := []int{1, 3, 5, 7, 9}
+
+	if got := slices.Collect(s.Iterator); !slices.Equal(got, want) {
+		t.Fatalf("Iterator yielded %v, want %v", got, want)
+	}
+
+	// adding out of order keeps things sorted
+	s.Add(4)
+	s.Add(0)
+	want = []int{0, 1, 3, 4, 5, 7, 9}
+	if got := slices.Collect(s.Iterator); !slices.Equal(got, want) {
+		t.Fatalf("after Add: Iterator yielded %v, want %v", got, want)
+	}
+
+	for i, v := range want {
+		got, ok := s.At(i)
+		if !ok || got != v {
+			t.Fatalf("At(%d) = %d, %v, want %d, true", i, got, ok, v)
+		}
+		if idx := s.Index(v); idx != i {
+			t.Fatalf("Index(%d) = %d, want %d", v, idx, i)
+		}
+	}
+
+	if _, ok := s.At(-1); ok {
+		t.Fatal("At(-1): expected ok=false")
+	}
+	if _, ok := s.At(len(want)); ok {
+		t.Fatalf("At(%d): expected ok=false", len(want))
+	}
+	if idx := s.Index(2); idx != -1 {
+		t.Fatalf("Index(2) = %d, want -1", idx)
+	}
+
+	if v, ok := First(s); !ok || v != 0 {
+		t.Fatalf("First = %d, %v, want 0, true", v, ok)
+	}
+	if v, ok := Last(s); !ok || v != 9 {
+		t.Fatalf("Last = %d, %v, want 9, true", v, ok)
+	}
+
+	// Backwards yields descending values with their ascending indexes
+	var gotIdx, gotVals []int
+	s.Backwards(func(i, v int) bool {
+		gotIdx = append(gotIdx, i)
+		gotVals = append(gotVals, v)
+		return true
+	})
+	if !slices.Equal(gotIdx, []int{6, 5, 4, 3, 2, 1, 0}) {
+		t.Fatalf("Backwards indexes = %v", gotIdx)
+	}
+	if !slices.Equal(gotVals, []int{9, 7, 5, 4, 3, 1, 0}) {
+		t.Fatalf("Backwards values = %v", gotVals)
+	}
+}
+
+func TestSortedSet_IterationEarlyStop(t *testing.T) {
+	t.Parallel()
+
+	s := NewSortedSetWith(1, 2, 3, 4, 5)
+
+	var got []int
+	s.Iterator(func(v int) bool {
+		got = append(got, v)
+		return len(got) < 2
+	})
+	if !slices.Equal(got, []int{1, 2}) {
+		t.Fatalf("Iterator early stop yielded %v", got)
+	}
+
+	got = nil
+	s.Ordered(func(_, v int) bool {
+		got = append(got, v)
+		return false
+	})
+	if !slices.Equal(got, []int{1}) {
+		t.Fatalf("Ordered early stop yielded %v", got)
+	}
+
+	got = nil
+	s.Backwards(func(_, v int) bool {
+		got = append(got, v)
+		return false
+	})
+	if !slices.Equal(got, []int{5}) {
+		t.Fatalf("Backwards early stop yielded %v", got)
+	}
+
+	got = nil
+	for v := range s.Range(2, 5) {
+		got = append(got, v)
+		if len(got) == 2 {
+			break
+		}
+	}
+	if !slices.Equal(got, []int{2, 3}) {
+		t.Fatalf("Range early stop yielded %v", got)
+	}
+}
+
+func TestSortedSet_Range(t *testing.T) {
+	t.Parallel()
+
+	s := NewSortedSetWith(10, 20, 30, 40, 50)
+
+	cases := []struct {
+		name   string
+		lo, hi int
+		want   []int
+	}{
+		{"inclusive both ends", 20, 40, []int{20, 30, 40}},
+		{"bounds between elements", 15, 45, []int{20, 30, 40}},
+		{"covers everything", -100, 100, []int{10, 20, 30, 40, 50}},
+		{"single element", 30, 30, []int{30}},
+		{"below all", -10, 5, nil},
+		{"above all", 60, 100, nil},
+		{"lo > hi", 40, 20, nil},
+	}
+	for _, tc := range cases {
+		if got := slices.Collect(s.Range(tc.lo, tc.hi)); !slices.Equal(got, tc.want) {
+			t.Fatalf("%s: Range(%d, %d) yielded %v, want %v", tc.name, tc.lo, tc.hi, got, tc.want)
+		}
+	}
+
+	empty := NewSortedSet[int]()
+	if got := slices.Collect(empty.Range(0, 100)); got != nil {
+		t.Fatalf("Range on empty set yielded %v", got)
+	}
+}
+
+func TestSortedSet_Pop(t *testing.T) {
+	t.Parallel()
+
+	s := NewSortedSetWith(3, 1, 2)
+	for _, want := range []int{3, 2, 1} {
+		v, ok := s.Pop()
+		if !ok || v != want {
+			t.Fatalf("Pop() = %d, %v, want %d, true", v, ok, want)
+		}
+	}
+	if v, ok := s.Pop(); ok {
+		t.Fatalf("Pop() on empty set = %d, true, want ok=false", v)
+	}
+}
+
+func TestSortedSet_ZeroValue(t *testing.T) {
+	t.Parallel()
+
+	var s SortedSet[int]
+	if s.Cardinality() != 0 {
+		t.Fatalf("zero value Cardinality() = %d", s.Cardinality())
+	}
+	if s.Contains(1) {
+		t.Fatal("zero value Contains(1) = true")
+	}
+	if n := s.Clear(); n != 0 {
+		t.Fatalf("zero value Clear() = %d", n)
+	}
+	if !s.Add(2) || !s.Add(1) {
+		t.Fatal("zero value Add failed")
+	}
+	if got := slices.Collect(s.Iterator); !slices.Equal(got, []int{1, 2}) {
+		t.Fatalf("zero value Iterator yielded %v", got)
+	}
+	if !s.Remove(1) {
+		t.Fatal("zero value Remove(1) failed")
+	}
+
+	var nilSafe *SortedSet[int]
+	if nilSafe.Cardinality() != 0 {
+		t.Fatal("nil receiver Cardinality() != 0")
+	}
+}
+
+func TestSortedSet_CloneAndNewEmpty(t *testing.T) {
+	t.Parallel()
+
+	s := NewSortedSetWith(1, 2, 3)
+
+	c := s.Clone()
+	if _, ok := c.(*SortedSet[int]); !ok {
+		t.Fatalf("Clone() returned %T, want *SortedSet[int]", c)
+	}
+	if !Equal(s, c) {
+		t.Fatalf("Clone() = %v, want %v", Elements(c), Elements(s))
+	}
+	// clone is independent of the original
+	c.Add(4)
+	if s.Contains(4) {
+		t.Fatal("mutating the clone changed the original")
+	}
+	s.Remove(1)
+	if !c.Contains(1) {
+		t.Fatal("mutating the original changed the clone")
+	}
+
+	if _, ok := s.NewEmpty().(*SortedSet[int]); !ok {
+		t.Fatalf("NewEmpty() returned %T, want *SortedSet[int]", s.NewEmpty())
+	}
+	if _, ok := s.NewEmptyOrdered().(*SortedSet[int]); !ok {
+		t.Fatalf("NewEmptyOrdered() returned %T, want *SortedSet[int]", s.NewEmptyOrdered())
+	}
+}
+
+func TestSortedSet_EqualOrdered(t *testing.T) {
+	t.Parallel()
+
+	s := NewSortedSetWith(3, 1, 2)
+
+	o := NewOrderedWith(3, 1, 2)
+	o.Sort()
+	if !EqualOrdered(s, o) {
+		t.Fatalf("expected %v to equal sorted Ordered %v", Elements(s), Elements(o))
+	}
+
+	unsorted := NewOrderedWith(3, 1, 2)
+	if EqualOrdered(s, unsorted) {
+		t.Fatalf("expected %v to differ from insertion-ordered %v", Elements(s), Elements(unsorted))
+	}
+	if !Equal(s, unsorted) {
+		t.Fatal("expected sets to be Equal regardless of order")
+	}
+}
+
+func TestSortedSet_String(t *testing.T) {
+	t.Parallel()
+
+	s := NewSortedSetWith(2, 1)
+	if got, want := s.String(), "SortedSet[int]([1 2])"; got != want {
+		t.Fatalf("String() = %q, want %q", got, want)
+	}
+}
+
+func TestSortedSet_JSON(t *testing.T) {
+	t.Parallel()
+
+	a := NewSortedSet[int]()
+	a.Add(2)
+	a.Add(1)
+
+	j, err := json.Marshal(a)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// marshals in ascending order
+	if string(j) != "[1,2]" {
+		t.Fatalf("MarshalJSON = %s, want [1,2]", j)
+	}
+	var b *SortedSet[int]
+	if err = json.Unmarshal(j, &b); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !Equal(a, b) {
+		t.Fatalf("expected %v, got %v", Elements(a), Elements(b))
+	}
+
+	// unsorted input with duplicates is sorted and de-duplicated
+	var c SortedSet[int]
+	if err := json.Unmarshal([]byte("[3,1,2,3,1]"), &c); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := slices.Collect(c.Iterator); !slices.Equal(got, []int{1, 2, 3}) {
+		t.Fatalf("unmarshal of unsorted input yielded %v", got)
+	}
+
+	// invalid JSON errors
+	if err := json.Unmarshal([]byte("{"), &c); err == nil {
+		t.Fatal("expected error unmarshaling invalid JSON")
+	}
+	// element type mismatch errors and leaves the set unchanged
+	if err := c.UnmarshalJSON([]byte(`["a","b"]`)); err == nil {
+		t.Fatal("expected error unmarshaling mismatched element type")
+	}
+	if got := slices.Collect(c.Iterator); !slices.Equal(got, []int{1, 2, 3}) {
+		t.Fatalf("set changed after failed unmarshal: %v", got)
+	}
+
+	// empty set marshals to an empty array
+	j, err = json.Marshal(NewSortedSet[int]())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(j) != "[]" {
+		t.Fatalf("empty MarshalJSON = %s, want []", j)
+	}
+
+	// values JSON can't represent error
+	if _, err := NewSortedSetWith(math.NaN()).MarshalJSON(); err == nil {
+		t.Fatal("expected error marshaling NaN")
+	}
+
+	type Bar struct {
+		Set *SortedSet[int]
+	}
+
+	d := Bar{Set: NewSortedSetWith(2, 1)}
+	j, err = json.Marshal(d)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var e Bar
+	if err = json.Unmarshal(j, &e); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !Equal(d.Set, e.Set) {
+		t.Fatalf("expected %v, got %v", Elements(d.Set), Elements(e.Set))
+	}
+}
+
+func TestSortedSet_ValueScan(t *testing.T) {
+	t.Parallel()
+
+	s := NewSortedSetWith(3, 1, 2)
+	v, err := s.Value()
+	if err != nil {
+		t.Fatalf("Value() error: %v", err)
+	}
+	b, ok := v.([]byte)
+	if !ok {
+		t.Fatalf("Value() returned %T, want []byte", v)
+	}
+
+	got := NewSortedSet[int]()
+	if err := got.Scan(b); err != nil {
+		t.Fatalf("Scan([]byte) error: %v", err)
+	}
+	if !Equal(s, got) {
+		t.Fatalf("Scan([]byte) = %v, want %v", Elements(got), Elements(s))
+	}
+
+	got = NewSortedSet[int]()
+	if err := got.Scan(string(b)); err != nil {
+		t.Fatalf("Scan(string) error: %v", err)
+	}
+	if !Equal(s, got) {
+		t.Fatalf("Scan(string) = %v, want %v", Elements(got), Elements(s))
+	}
+
+	// nil clears the set
+	if err := got.Scan(nil); err != nil {
+		t.Fatalf("Scan(nil) error: %v", err)
+	}
+	if got.Cardinality() != 0 {
+		t.Fatalf("Scan(nil) left %d elements", got.Cardinality())
+	}
+
+	if err := got.Scan(42); err == nil {
+		t.Fatal("expected error scanning unsupported type")
+	}
+}
+
+func TestSortedSet_Clear(t *testing.T) {
+	t.Parallel()
+
+	s := NewSortedSetWith(1, 2, 3)
+	if n := s.Clear(); n != 3 {
+		t.Fatalf("Clear() = %d, want 3", n)
+	}
+	if s.Cardinality() != 0 {
+		t.Fatalf("Cardinality() after Clear = %d", s.Cardinality())
+	}
+	// reusable after Clear
+	s.Add(9)
+	s.Add(4)
+	if got := slices.Collect(s.Iterator); !slices.Equal(got, []int{4, 9}) {
+		t.Fatalf("Iterator after Clear yielded %v", got)
+	}
+}
+
+func TestSortedSet_From(t *testing.T) {
+	t.Parallel()
+
+	s := NewSortedSetFrom(slices.Values([]int{5, 5, 2, 8, 2}))
+	if got := slices.Collect(s.Iterator); !slices.Equal(got, []int{2, 5, 8}) {
+		t.Fatalf("NewSortedSetFrom yielded %v", got)
+	}
+
+	empty := NewSortedSetFrom(slices.Values([]int(nil)))
+	if empty.Cardinality() != 0 {
+		t.Fatalf("NewSortedSetFrom(empty) has %d elements", empty.Cardinality())
+	}
+}

--- a/stresstest/sorted_stress_test.go
+++ b/stresstest/sorted_stress_test.go
@@ -1,0 +1,167 @@
+package stresstest
+
+import (
+	"math/rand/v2"
+	"slices"
+	"testing"
+
+	"github.com/freeformz/sets"
+)
+
+// unsortedModel is a slice-backed reference implementation of a set. Membership is tracked in
+// insertion order and sorted on demand, so it shares no logic with SortedSet's
+// binary-search-and-shift approach.
+type unsortedModel struct{ el []int }
+
+func (r *unsortedModel) add(v int) bool {
+	if slices.Contains(r.el, v) {
+		return false
+	}
+	r.el = append(r.el, v)
+	return true
+}
+
+func (r *unsortedModel) remove(v int) bool {
+	i := slices.Index(r.el, v)
+	if i < 0 {
+		return false
+	}
+	r.el = slices.Delete(r.el, i, i+1)
+	return true
+}
+
+// sorted returns the expected element view: ascending order.
+func (r *unsortedModel) sorted() []int {
+	out := slices.Clone(r.el)
+	slices.Sort(out)
+	return out
+}
+
+// TestSortedSetDifferential runs randomized Add/Remove/Sort/Pop/Clear sequences against SortedSet
+// and an unsorted reference model, verifying Cardinality, Iterator, At, Index, Ordered, Backwards,
+// and Range after every operation. The element domain (50) is deliberately small relative to the
+// operation count so sequences repeatedly grow, shrink, and empty the set, exercising the insertion
+// and deletion shift paths at every position.
+func TestSortedSetDifferential(t *testing.T) {
+	t.Parallel()
+
+	trials := 250
+	if testing.Short() {
+		trials = 25
+	}
+
+	for trial := range trials {
+		rng := rand.New(rand.NewPCG(uint64(trial), 0x50e7ed5e7))
+		s := sets.NewSortedSet[int]()
+		var r unsortedModel
+		for op := range 300 {
+			sortedStep(t, rng, s, &r, trial, op)
+			sortedCheck(t, rng, s, &r, trial, op)
+		}
+	}
+}
+
+// sortedStep applies one random operation to both the set and the reference model.
+func sortedStep(t *testing.T, rng *rand.Rand, s *sets.SortedSet[int], r *unsortedModel, trial, op int) {
+	t.Helper()
+	switch rng.IntN(10) {
+	case 0, 1, 2, 3:
+		v := rng.IntN(50)
+		if got, want := s.Add(v), r.add(v); got != want {
+			t.Fatalf("trial %d op %d: Add(%d) = %t, want %t", trial, op, v, got, want)
+		}
+	case 4, 5, 6:
+		v := rng.IntN(50)
+		if got, want := s.Remove(v), r.remove(v); got != want {
+			t.Fatalf("trial %d op %d: Remove(%d) = %t, want %t", trial, op, v, got, want)
+		}
+	case 7:
+		s.Sort() // no-op for SortedSet; the model needs no change either
+	case 8:
+		v, ok := s.Pop()
+		if ok != (len(r.el) > 0) {
+			t.Fatalf("trial %d op %d: Pop() ok = %t with %d elements", trial, op, ok, len(r.el))
+		}
+		if ok {
+			if want := r.sorted()[len(r.el)-1]; v != want {
+				t.Fatalf("trial %d op %d: Pop() = %d, want the maximum %d", trial, op, v, want)
+			}
+			if !r.remove(v) {
+				t.Fatalf("trial %d op %d: Pop() returned %d, not in the set", trial, op, v)
+			}
+		}
+	case 9:
+		if rng.IntN(10) == 0 {
+			if got := s.Clear(); got != len(r.el) {
+				t.Fatalf("trial %d op %d: Clear() = %d, want %d", trial, op, got, len(r.el))
+			}
+			r.el = nil
+		}
+	}
+}
+
+// sortedCheck verifies every read-side invariant of s against the reference model.
+func sortedCheck(t *testing.T, rng *rand.Rand, s *sets.SortedSet[int], r *unsortedModel, trial, op int) {
+	t.Helper()
+	want := r.sorted()
+
+	if got := s.Cardinality(); got != len(want) {
+		t.Fatalf("trial %d op %d: Cardinality() = %d, want %d", trial, op, got, len(want))
+	}
+	if got := slices.Collect(s.Iterator); !slices.Equal(got, want) {
+		t.Fatalf("trial %d op %d: Iterator yielded %v, want %v", trial, op, got, want)
+	}
+
+	for i, v := range want {
+		got, ok := s.At(i)
+		if !ok || got != v {
+			t.Fatalf("trial %d op %d: At(%d) = %d, %t, want %d, true", trial, op, i, got, ok, v)
+		}
+		if idx := s.Index(v); idx != i {
+			t.Fatalf("trial %d op %d: Index(%d) = %d, want %d", trial, op, v, idx, i)
+		}
+	}
+	if _, ok := s.At(-1); ok {
+		t.Fatalf("trial %d op %d: At(-1) ok = true", trial, op)
+	}
+	if _, ok := s.At(len(want)); ok {
+		t.Fatalf("trial %d op %d: At(%d) ok = true", trial, op, len(want))
+	}
+
+	var ordered []int
+	s.Ordered(func(i, v int) bool {
+		if i != len(ordered) {
+			t.Fatalf("trial %d op %d: Ordered index = %d, want %d", trial, op, i, len(ordered))
+		}
+		ordered = append(ordered, v)
+		return true
+	})
+	if !slices.Equal(ordered, want) {
+		t.Fatalf("trial %d op %d: Ordered yielded %v, want %v", trial, op, ordered, want)
+	}
+
+	var backwards []int
+	s.Backwards(func(i, v int) bool {
+		if i != len(want)-1-len(backwards) {
+			t.Fatalf("trial %d op %d: Backwards index = %d, want %d", trial, op, i, len(want)-1-len(backwards))
+		}
+		backwards = append(backwards, v)
+		return true
+	})
+	slices.Reverse(backwards)
+	if !slices.Equal(backwards, want) {
+		t.Fatalf("trial %d op %d: Backwards yielded %v, want %v", trial, op, backwards, want)
+	}
+
+	// Range with random bounds (possibly inverted) against a filtered model view.
+	lo, hi := rng.IntN(60)-5, rng.IntN(60)-5
+	var wantRange []int
+	for _, v := range want {
+		if v >= lo && v <= hi {
+			wantRange = append(wantRange, v)
+		}
+	}
+	if got := slices.Collect(s.Range(lo, hi)); !slices.Equal(got, wantRange) {
+		t.Fatalf("trial %d op %d: Range(%d, %d) yielded %v, want %v", trial, op, lo, hi, got, wantRange)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `SortedSet[M cmp.Ordered]`, a new `OrderedSet` implementation backed by a single sorted slice (no companion map) that maintains ascending order as a permanent invariant rather than a transient state (unlike `Ordered.Sort()`).
- O(log n) `Contains`/`Index`, O(1) `At`, O(n) `Add`/`Remove` (binary search + shift), O(1) `Pop` (removes the max). Best suited to read-heavy / build-once-query-many workloads.
- Adds `Range(lo, hi)`, a new binary-search-bounded range query iterator, exclusive to `SortedSet`.
- Constructors: `NewSortedSet`, `NewSortedSetFrom`, `NewSortedSetWith`. Implements `json.Marshaler`/`Unmarshaler`, `sql.Scanner`, `driver.Valuer` like the other set types.
- Added to the benchmark suite, README, and CLAUDE.md.

## Test plan
- [x] `go test -v -race ./...`
- [x] `go vet ./...`
- [x] `staticcheck ./...`
- [x] New rapid state-machine test (`TestSortedSet`) using the existing shared `SetStateMachine` spec
- [x] New rapid invariant test (`TestSortedSet_Invariant`) checking strict ascending order + cardinality against a map model
- [x] New differential stress test (`stresstest/sorted_stress_test.go`, 250 trials × 300 ops) against an independent reference model, covering `At`/`Index`/`Ordered`/`Backwards`/`Range`
- [x] Unit tests for ordering, `Range` edge cases, early-terminating iteration, `Pop`, `Clear`, zero-value/nil-receiver safety, clone independence, JSON round-trips (including error paths), `Value`/`Scan`
- [x] 4 new runnable examples
- [x] 100% statement coverage of `sorted.go` (excluding the no-op `Sort()` body, which has no statements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)