### PR TITLE
fix: nil-receiver safety, SortedSet.Pop contract, and coverage hardening

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -61,7 +61,7 @@ These helpers work on all Set types, including OrderedSets.
 * `sets.Elements(aSet)` : Elements of the set as a slice.
 * `sets.AppendSeq(aSet,sequence)` : Append the items in the sequence (an iterator) to the set.
 * `sets.RemoveSeq(aSet,sequence)` : Remove the items in the sequence (an iterator) from the set.
-* `sets.Union(aSet,bSet)` : Returns a new set (of the same underling type as aSet) with all elements from both sets.
+* `sets.Union(aSet,bSet)` : Returns a new set (of the same underlying type as aSet) with all elements from both sets.
 * `sets.Intersection(aSet,bSet)` : Returns a new set (of the same underlying type as aSet) with elements that are in both sets.
 * `sets.Difference(aSet,bSet)` : Returns a new set (of the same underlying type as aSet) with elements that are in the first set but not in the second set.
 * `sets.SymmetricDifference(aSet,bSet)` : Returns a new set (of the same underlying type as aSet) with elements that are not in both sets.
@@ -73,7 +73,7 @@ These helpers work on all Set types, including OrderedSets.
 * `sets.Iter2(sequence)` : Returns a (int,V) iterator where the int represents a "pseudo" index.
 * `sets.Max(aSet)` : Returns the max element in the set as determined by the max builtin.
 * `sets.Min(aSet)` : Returns the min element in the set as determined by the min builtin.
-* `sets.Chunk(aSet,n)` : Chunks the set into n sets of equal size. The last set will have fewer elements if the cardinality of the set is not a multiple of n.
+* `sets.Chunk(aSet,n)` : Chunks the set into sets of n elements each. The last set will have fewer elements if the cardinality of the set is not a multiple of n.
 * `sets.IsEmpty(aSet)` : Returns true if the set is empty, otherwise false.
 * `sets.MapBy(aSet, func(v V) X { return ... }) bSet` : Maps the elements of the set to a new set.
 * `sets.MapTo(aSet, bSet, func(v V) X { return ... })` : Maps the elements of aSet into bSet.
@@ -86,7 +86,7 @@ These helpers work on all Set types, including OrderedSets.
 * `sets.All(aSet, func(v V) bool { return true/false })` : Returns true if all elements in the set satisfy the predicate. Short-circuits on the first non-match.
 * `sets.ContainsAll(aSet, elements...)` : Returns true if the set contains all of the provided elements.
 * `sets.ContainsAny(aSet, elements...)` : Returns true if the set contains at least one of the provided elements.
-* `sets.Random(aSet)` : Returns a random element from the set without removing it. O(1) for ordered sets, O(n) for unordered sets.
+* `sets.Random(aSet)` : Returns a random element from the set without removing it. Uses indexed access for ordered sets (O(log n) or better for this package's implementations), O(n) for unordered sets.
 
 ## OrderedSet Helpers
 

--- a/coverage_test.go
+++ b/coverage_test.go
@@ -1,0 +1,308 @@
+package sets
+
+import (
+	"cmp"
+	"encoding/json"
+	"math"
+	"slices"
+	"testing"
+)
+
+// plainSet delegates to an embedded Set but does not implement json.Marshaler,
+// json.Unmarshaler, or Locker, exercising the wrapper types' error branches.
+type plainSet[M comparable] struct {
+	Set[M]
+}
+
+// plainOrdered is the OrderedSet analog of plainSet.
+type plainOrdered[M cmp.Ordered] struct {
+	OrderedSet[M]
+}
+
+// lyingSet reports a non-zero cardinality while iterating nothing, exercising
+// Random's fallback return for misbehaving Set implementations.
+type lyingSet struct {
+	Set[int]
+}
+
+func (lyingSet) Cardinality() int { return 1 }
+
+func TestFilterTo(t *testing.T) {
+	t.Parallel()
+
+	src := NewWith(1, 2, 3, 4)
+	dst := New[int]()
+	FilterTo(src, dst, func(i int) bool { return i%2 == 0 })
+	if !Equal(dst, NewWith(2, 4)) {
+		t.Fatalf("FilterTo yielded %v, want [2 4]", Elements(dst))
+	}
+}
+
+func TestString(t *testing.T) {
+	t.Parallel()
+
+	if got, want := NewLockedWith(1).String(), "LockedSet[int]([1])"; got != want {
+		t.Fatalf("Locked.String() = %q, want %q", got, want)
+	}
+	if got, want := NewLockedOrderedWith(1).String(), "LockedOrderedSet[int]([1])"; got != want {
+		t.Fatalf("LockedOrdered.String() = %q, want %q", got, want)
+	}
+	if got, want := NewSyncMapWith(1).String(), "SyncSet[int]([1])"; got != want {
+		t.Fatalf("SyncMap.String() = %q, want %q", got, want)
+	}
+}
+
+func TestLockedOrdered_OrderedAccessors(t *testing.T) {
+	t.Parallel()
+
+	s := NewLockedOrderedWith(3, 1, 2)
+
+	var idx, vals []int
+	s.Ordered(func(i, v int) bool {
+		idx = append(idx, i)
+		vals = append(vals, v)
+		return true
+	})
+	if !slices.Equal(idx, []int{0, 1, 2}) || !slices.Equal(vals, []int{3, 1, 2}) {
+		t.Fatalf("Ordered yielded idx=%v vals=%v", idx, vals)
+	}
+	vals = nil
+	s.Ordered(func(_, v int) bool {
+		vals = append(vals, v)
+		return false
+	})
+	if !slices.Equal(vals, []int{3}) {
+		t.Fatalf("Ordered early stop yielded %v", vals)
+	}
+
+	idx, vals = nil, nil
+	s.Backwards(func(i, v int) bool {
+		idx = append(idx, i)
+		vals = append(vals, v)
+		return true
+	})
+	if !slices.Equal(idx, []int{2, 1, 0}) || !slices.Equal(vals, []int{2, 1, 3}) {
+		t.Fatalf("Backwards yielded idx=%v vals=%v", idx, vals)
+	}
+	vals = nil
+	s.Backwards(func(_, v int) bool {
+		vals = append(vals, v)
+		return false
+	})
+	if !slices.Equal(vals, []int{2}) {
+		t.Fatalf("Backwards early stop yielded %v", vals)
+	}
+
+	if got := s.Index(1); got != 1 {
+		t.Fatalf("Index(1) = %d, want 1", got)
+	}
+	if got := s.Index(99); got != -1 {
+		t.Fatalf("Index(99) = %d, want -1", got)
+	}
+
+	s.Sort()
+	if got := slices.Collect(s.Iterator); !slices.Equal(got, []int{1, 2, 3}) {
+		t.Fatalf("after Sort: Iterator yielded %v", got)
+	}
+}
+
+func TestWrappingAlreadyLocked(t *testing.T) {
+	t.Parallel()
+
+	l := NewLocked[int]()
+	if got := NewLockedWrapping(l); got != Set[int](l) {
+		t.Fatalf("NewLockedWrapping returned %T, want the original locked set", got)
+	}
+	lo := NewLockedOrdered[int]()
+	if got := NewLockedOrderedWrapping(lo); got != OrderedSet[int](lo) {
+		t.Fatalf("NewLockedOrderedWrapping returned %T, want the original locked set", got)
+	}
+}
+
+func TestNilReceiverCardinality(t *testing.T) {
+	t.Parallel()
+
+	var m *Map[int]
+	var o *Ordered[int]
+	var sm *SyncMap[int]
+	var l *Locked[int]
+	var lo *LockedOrdered[int]
+	var ss *SortedSet[int]
+	for i, c := range []int{
+		m.Cardinality(), o.Cardinality(), sm.Cardinality(),
+		l.Cardinality(), lo.Cardinality(), ss.Cardinality(),
+	} {
+		if c != 0 {
+			t.Fatalf("nil receiver Cardinality() #%d = %d, want 0", i, c)
+		}
+	}
+}
+
+func TestZeroValueWrappers(t *testing.T) {
+	t.Parallel()
+
+	var m Map[int]
+	if c := m.Clone(); c.Cardinality() != 0 || !c.Add(1) {
+		t.Fatal("zero value Map.Clone() is not an empty usable set")
+	}
+
+	var l Locked[int]
+	if c := l.Clone(); c.Cardinality() != 0 {
+		t.Fatalf("zero value Locked.Clone() has %d elements", c.Cardinality())
+	}
+	if e := l.NewEmpty(); e.Cardinality() != 0 {
+		t.Fatalf("zero value Locked.NewEmpty() has %d elements", e.Cardinality())
+	}
+	var l2 Locked[int]
+	if err := l2.UnmarshalJSON([]byte(`[1,2]`)); err != nil {
+		t.Fatalf("zero value Locked.UnmarshalJSON error: %v", err)
+	}
+	if l2.Cardinality() != 2 {
+		t.Fatalf("zero value Locked after UnmarshalJSON has %d elements", l2.Cardinality())
+	}
+	var l3 Locked[int]
+	if err := l3.Scan([]byte(`[1]`)); err != nil {
+		t.Fatalf("zero value Locked.Scan error: %v", err)
+	}
+
+	var lo LockedOrdered[int]
+	if c := lo.Clone(); c.Cardinality() != 0 {
+		t.Fatalf("zero value LockedOrdered.Clone() has %d elements", c.Cardinality())
+	}
+	if e := lo.NewEmptyOrdered(); e.Cardinality() != 0 {
+		t.Fatalf("zero value LockedOrdered.NewEmptyOrdered() has %d elements", e.Cardinality())
+	}
+	var lo2 LockedOrdered[int]
+	if err := lo2.UnmarshalJSON([]byte(`[1,2]`)); err != nil {
+		t.Fatalf("zero value LockedOrdered.UnmarshalJSON error: %v", err)
+	}
+	var lo3 LockedOrdered[int]
+	if err := lo3.Scan([]byte(`[1]`)); err != nil {
+		t.Fatalf("zero value LockedOrdered.Scan error: %v", err)
+	}
+}
+
+func TestEqualSubsetSameCardinality(t *testing.T) {
+	t.Parallel()
+
+	if Equal(NewWith(1, 2), NewWith(1, 3)) {
+		t.Fatal("Equal on same-cardinality different sets returned true")
+	}
+	if Subset(NewWith(1, 5), NewWith(1, 2, 3)) {
+		t.Fatal("Subset returned true for a non-subset of larger cardinality")
+	}
+}
+
+func TestIter2EarlyStop(t *testing.T) {
+	t.Parallel()
+
+	var seen []int
+	for i := range Iter2(NewOrderedWith(1, 2, 3).Iterator) {
+		seen = append(seen, i)
+		break
+	}
+	if !slices.Equal(seen, []int{0}) {
+		t.Fatalf("Iter2 early stop yielded %v", seen)
+	}
+}
+
+func TestMinMaxPanicOnEmpty(t *testing.T) {
+	t.Parallel()
+
+	for name, fn := range map[string]func(){
+		"Max": func() { Max(New[int]()) },
+		"Min": func() { Min(New[int]()) },
+	} {
+		func() {
+			defer func() {
+				if recover() == nil {
+					t.Fatalf("%s on empty set did not panic", name)
+				}
+			}()
+			fn()
+		}()
+	}
+}
+
+func TestChunkPanicAndEarlyStop(t *testing.T) {
+	t.Parallel()
+
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("Chunk with n=0 did not panic")
+			}
+		}()
+		Chunk(New[int](), 0)
+	}()
+
+	var chunks int
+	for range Chunk(NewOrderedWith(1, 2, 3, 4, 5), 2) {
+		chunks++
+		break
+	}
+	if chunks != 1 {
+		t.Fatalf("Chunk early stop yielded %d chunks", chunks)
+	}
+}
+
+func TestOrderedBackwardsEarlyStop(t *testing.T) {
+	t.Parallel()
+
+	var vals []int
+	NewOrderedWith(1, 2, 3).Backwards(func(_, v int) bool {
+		vals = append(vals, v)
+		return false
+	})
+	if !slices.Equal(vals, []int{3}) {
+		t.Fatalf("Backwards early stop yielded %v", vals)
+	}
+}
+
+func TestMarshalJSONErrors(t *testing.T) {
+	t.Parallel()
+
+	if _, err := NewOrderedWith(math.NaN()).MarshalJSON(); err == nil {
+		t.Fatal("Ordered.MarshalJSON(NaN) did not error")
+	}
+	if _, err := NewLockedWith(math.NaN()).MarshalJSON(); err == nil {
+		t.Fatal("Locked.MarshalJSON(NaN) did not error")
+	}
+	if _, err := NewLockedOrderedWith(math.NaN()).MarshalJSON(); err == nil {
+		t.Fatal("LockedOrdered.MarshalJSON(NaN) did not error")
+	}
+}
+
+func TestLockedWrappingNonJSONSet(t *testing.T) {
+	t.Parallel()
+
+	w := NewLockedWrapping(plainSet[int]{New[int]()})
+	if _, err := w.(json.Marshaler).MarshalJSON(); err == nil {
+		t.Fatal("MarshalJSON of a wrapped non-marshaler set did not error")
+	}
+	if err := w.(json.Unmarshaler).UnmarshalJSON([]byte(`[1]`)); err == nil {
+		t.Fatal("UnmarshalJSON of a wrapped non-unmarshaler set did not error")
+	}
+	if err := w.(interface{ Scan(any) error }).Scan([]byte(`[1]`)); err == nil {
+		t.Fatal("Scan of a wrapped non-unmarshaler set did not error")
+	}
+
+	wo := NewLockedOrderedWrapping(plainOrdered[int]{NewOrdered[int]()})
+	if _, err := wo.(json.Marshaler).MarshalJSON(); err == nil {
+		t.Fatal("MarshalJSON of a wrapped non-marshaler ordered set did not error")
+	}
+	if err := wo.(json.Unmarshaler).UnmarshalJSON([]byte(`[1]`)); err == nil {
+		t.Fatal("UnmarshalJSON of a wrapped non-unmarshaler ordered set did not error")
+	}
+	if err := wo.(interface{ Scan(any) error }).Scan([]byte(`[1]`)); err == nil {
+		t.Fatal("Scan of a wrapped non-unmarshaler ordered set did not error")
+	}
+}
+
+func TestRandomMisbehavingSet(t *testing.T) {
+	t.Parallel()
+
+	if _, ok := Random(lyingSet{New[int]()}); ok {
+		t.Fatal("Random on a set that iterates nothing returned ok=true")
+	}
+}

--- a/locked.go
+++ b/locked.go
@@ -84,6 +84,9 @@ func (s *Locked[M]) Remove(m M) bool {
 
 // Cardinality returns the number of elements in the set.
 func (s *Locked[M]) Cardinality() int {
+	if s == nil {
+		return 0
+	}
 	s.RLock()
 	defer s.RUnlock()
 

--- a/locked_ordered.go
+++ b/locked_ordered.go
@@ -80,6 +80,9 @@ func (s *LockedOrdered[M]) Remove(m M) bool {
 
 // Cardinality returns the number of elements in the set.
 func (s *LockedOrdered[M]) Cardinality() int {
+	if s == nil {
+		return 0
+	}
 	s.RLock()
 	defer s.RUnlock()
 

--- a/map.go
+++ b/map.go
@@ -79,6 +79,9 @@ func (s *Map[M]) Remove(m M) bool {
 
 // Cardinality returns the number of elements in the set.
 func (s *Map[M]) Cardinality() int {
+	if s == nil {
+		return 0
+	}
 	return len(s.set)
 }
 

--- a/ordered_set.go
+++ b/ordered_set.go
@@ -65,6 +65,8 @@ func IsSorted[K cmp.Ordered](s OrderedSet[K]) bool {
 }
 
 // Reverse returns a new OrderedSet with the elements in the reverse order of the original OrderedSet.
+// Always-sorted implementations (e.g. SortedSet) cannot hold elements out of ascending order, so
+// reversing one returns a set with the same ascending order as the original.
 func Reverse[K cmp.Ordered](s OrderedSet[K]) OrderedSet[K] {
 	out := s.NewEmptyOrdered()
 	AppendSeq(out, func(yield func(k K) bool) {
@@ -93,6 +95,7 @@ func ReduceRight[K cmp.Ordered, O any](s OrderedSet[K], initial O, fn func(agg O
 	return out
 }
 
+// ForEachRight calls the function with each element in the set in reverse order.
 func ForEachRight[K cmp.Ordered](s OrderedSet[K], fn func(k K)) {
 	for _, k := range s.Backwards {
 		fn(k)

--- a/set.go
+++ b/set.go
@@ -1,5 +1,5 @@
 // A set package with various set helper functions and set types.
-// Supports tha latest Go versions and features including generics
+// Supports the latest Go versions and features including generics
 // and iterators. The package is designed to be simple and easy to use
 // alongside the standard library.
 package sets
@@ -83,7 +83,7 @@ func RemoveSeq[K comparable](s Set[K], seq iter.Seq[K]) int {
 	return n
 }
 
-// Union of the two sets. Returns a new set (of the same underling type as a) with all elements from both sets.
+// Union of the two sets. Returns a new set (of the same underlying type as a) with all elements from both sets.
 func Union[K comparable](a, b Set[K]) Set[K] {
 	c := a.Clone()
 	AppendSeq(c, b.Iterator)
@@ -187,10 +187,10 @@ func Disjoint[K comparable](a, b Set[K]) bool {
 // Iter2 is a helper function that simplifies iterating over a set when an "index" is needed, by providing a pseudo-index
 // to the yield function. The index is not stable across iterations. The yield function is called for each element in the
 // set. If the yield function returns false, the iteration is stopped.
-func Iter2[K comparable](iter iter.Seq[K]) func(func(i int, k K) bool) {
+func Iter2[K comparable](seq iter.Seq[K]) func(func(i int, k K) bool) {
 	return func(yield func(i int, k K) bool) {
 		var i int
-		for k := range iter {
+		for k := range seq {
 			if !yield(i, k) {
 				return
 			}

--- a/set_test.go
+++ b/set_test.go
@@ -618,7 +618,7 @@ func TestOrdered_Remove(t *testing.T) {
 	}
 	s.Remove(2)
 	if s.Cardinality() != 4 {
-		t.Fatalf("expected 9 elements, got %d", s.Cardinality())
+		t.Fatalf("expected 4 elements, got %d", s.Cardinality())
 	}
 	values := slices.Collect(s.Iterator)
 

--- a/sorted.go
+++ b/sorted.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"iter"
+	"math/rand/v2"
 	"slices"
 )
 
@@ -153,15 +154,17 @@ func (s *SortedSet[M]) NewEmpty() Set[M] {
 	return NewSortedSet[M]()
 }
 
-// Pop removes and returns the largest element of the set. If the set is empty, it returns the zero
-// value of M and false. Removing from the end avoids the shift other removals pay, so Pop is O(1).
+// Pop removes and returns a random element from the set. If the set is empty, it returns the zero
+// value of M and false. Removing an element other than the largest shifts the elements after it,
+// so Pop is O(N).
 func (s *SortedSet[M]) Pop() (M, bool) {
 	if len(s.el) == 0 {
 		var m M
 		return m, false
 	}
-	m := s.el[len(s.el)-1]
-	s.el = slices.Delete(s.el, len(s.el)-1, len(s.el))
+	i := rand.IntN(len(s.el))
+	m := s.el[i]
+	s.el = slices.Delete(s.el, i, i+1)
 	return m, true
 }
 

--- a/sorted_test.go
+++ b/sorted_test.go
@@ -220,10 +220,21 @@ func TestSortedSet_Pop(t *testing.T) {
 	t.Parallel()
 
 	s := NewSortedSetWith(3, 1, 2)
-	for _, want := range []int{3, 2, 1} {
+	remaining := map[int]bool{1: true, 2: true, 3: true}
+	for range 3 {
 		v, ok := s.Pop()
-		if !ok || v != want {
-			t.Fatalf("Pop() = %d, %v, want %d, true", v, ok, want)
+		if !ok {
+			t.Fatalf("Pop() on non-empty set returned ok=false")
+		}
+		if !remaining[v] {
+			t.Fatalf("Pop() = %d, which was already popped or never present", v)
+		}
+		delete(remaining, v)
+		if s.Contains(v) {
+			t.Fatalf("Pop() returned %d but it is still in the set", v)
+		}
+		if !IsSorted(s) {
+			t.Fatalf("set not sorted after Pop: %v", Elements(s))
 		}
 	}
 	if v, ok := s.Pop(); ok {

--- a/stresstest/sorted_stress_test.go
+++ b/stresstest/sorted_stress_test.go
@@ -83,9 +83,6 @@ func sortedStep(t *testing.T, rng *rand.Rand, s *sets.SortedSet[int], r *unsorte
 			t.Fatalf("trial %d op %d: Pop() ok = %t with %d elements", trial, op, ok, len(r.el))
 		}
 		if ok {
-			if want := r.sorted()[len(r.el)-1]; v != want {
-				t.Fatalf("trial %d op %d: Pop() = %d, want the maximum %d", trial, op, v, want)
-			}
 			if !r.remove(v) {
 				t.Fatalf("trial %d op %d: Pop() returned %d, not in the set", trial, op, v)
 			}

--- a/sync.go
+++ b/sync.go
@@ -72,7 +72,6 @@ func (s *SyncMap[M]) Pop() (M, bool) {
 	s.m.Range(func(key, _ any) bool {
 		if _, ok = s.m.LoadAndDelete(key); ok {
 			m = key.(M)
-			ok = true
 			return false
 		}
 		return true


### PR DESCRIPTION
## Summary
- Guard `Cardinality()` against nil receivers on `Map`, `Locked`, and `LockedOrdered`, matching the existing behavior of `Ordered` and `SyncMap`.
- Fix `SortedSet.Pop` to remove a random element instead of always the largest one, honoring the `Set` interface's documented contract.
- Fix comment typos, avoid shadowing the `iter` package in `Iter2`, and drop a redundant assignment in `SyncMap.Pop`.
- Add coverage tests for nil-receiver handling, zero-value wrapper usability, `String()` formatting, wrapped non-JSON/non-Locker sets, and `Random`'s fallback for a misbehaving `Set`.

No API surface changes; ordinary bug fixes and hardening, so no version-bump token is included (defaults to a patch release).

## Test plan
- [x] `go build ./...`
- [x] `go test -v -race ./...`
- [x] `go vet ./...`
- [x] `staticcheck ./...`
- [x] gopls diagnostics on all touched files (clean)