### PR TITLE
ci: make Claude Code Review post its results to the PR

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,7 +38,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           # Surface the full Claude transcript in the Actions log so a run that posts
           # no comments can be diagnosed (found nothing vs. a blocked tool call).
           show_full_output: true


### PR DESCRIPTION
## Problem

The `Claude Code Review` workflow runs a full review on every PR but never posts anything back — most recently on #39, where it reviewed cleanly ($2.56, 67 turns) and left no comment.

## Root cause

Not a token/permission/config failure. The `code-review` marketplace plugin command (pulled fresh in CI from `anthropics/claude-code.git`) added an explicit gate:

> If `--comment` argument was NOT provided, stop here. Do not post any GitHub comments.

Our prompt omitted `--comment`, so the skill reviewed silently and stopped. The run's own final result said so verbatim: *"No `--comment` flag was passed, so no comments were posted to GitHub."*

## Fix

Add `--comment` to the prompt. With it:
- **No issues found** → posts a "No issues found" summary via `gh pr comment` (already allowlisted).
- **Issues found** → posts inline comments via the GitHub MCP that `claude-code-action@v1` provides under the existing `pull-requests: write` permission.

No other config changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xnatSsxtpgzuXiDGRzVfb