### PR TITLE
feat: Locked/LockedOrdered delegate all optional optimization interfaces #minor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,11 +31,11 @@ CI runs checks (staticcheck, vet) on Ubuntu and tests (with `-race`) across Ubun
 **Implementations**:
 - `Map[M]` (`map.go`) — default map-based set, created via `New()`
 - `SyncMap[M]` (`sync.go`) — `sync.Map`-based, concurrent-safe via `NewSyncMap()`
-- `Locked[M]` (`locked.go`) — RWMutex wrapper around a Set via `NewLocked()`
+- `Locked[M]` (`locked.go`) — RWMutex wrapper around a Set via `NewLocked()`. Delegates all optional optimization interfaces to the inner set under the read lock; operand wrapper locks are only try-acquired (declining to the generic path on contention), so delegation cannot deadlock
 - `Ordered[M]` (`ordered.go`) — insertion-ordered set via `NewOrdered()`
 - `SortedSet[M]` (`sorted.go`) — always-sorted set backed by a sorted slice via `NewSortedSet()`; read-optimized (O(log n) Contains, O(1) At, `Range(lo, hi)` queries), O(n) Add/Remove. Implements the four set-algebra optimization interfaces (O(n+m) linear merge when both operands are SortedSets), `Maxer`/`Minner` (O(1) from the slice ends), and the three predicate optimization interfaces (`Equaler`/`Disjointer`/`Subsetter`, short-circuiting scans)
 - `BitSet[M]` (`bitset.go`) — always-sorted dense-bitmap set for integer element types (`Integer` constraint, not `comparable`) via `NewBitSet()`; O(1) Add/Remove/Contains and word-wise set ops between two BitSets (via the exported optional single-method interfaces `Unioner[M]`/`Intersectioner[M]`/`Differencer[M]`/`SymmetricDifferencer[M]` in `set.go`, which any implementation can adopt in any combination to accelerate the package-level algebra functions; the optional `Maxer[M]`/`Minner[M]` interfaces accelerate package-level `Max`/`Min` the same way, and `Equaler[M]`/`Disjointer[M]`/`Subsetter[M]` accelerate the `Equal`/`Disjoint`/`Subset`/`Superset` predicates). Memory ∝ element span, not count — see the type's godoc for the tradeoffs; `Reserve`/`Compact` manage the backing array
-- `LockedOrdered[M]` (`locked_ordered.go`) — RWMutex wrapper around OrderedSet via `NewLockedOrdered()`
+- `LockedOrdered[M]` (`locked_ordered.go`) — RWMutex wrapper around OrderedSet via `NewLockedOrdered()`; same optional-interface delegation as `Locked`
 
 **Design philosophy**: Functionality lives in package-level generic functions (in `set.go` and `ordered_set.go`), not methods. This aligns with stdlib `slices`/`maps` style. Locked types use composition, wrapping an inner set with mutex protection.
 

--- a/README.MD
+++ b/README.MD
@@ -211,6 +211,12 @@ interfaces the same way (`Superset` is `Subset` with the operands swapped, so it
 short-circuiting scans of the two sorted slices, `BitSet` with word-wise comparisons. See the `Equaler` godoc for the
 contract.
 
+The locked wrappers (`Locked` and `LockedOrdered`) delegate every optional interface to their inner set under the read
+lock, so wrapping an optimizable set keeps its fast paths. When the other operand is itself a locked wrapper it is
+unwrapped with a non-blocking lock attempt; under contention the delegation declines into the generic path (which locks
+one set at a time), so delegation can never deadlock. Delegated set-algebra results come back wrapped, so they stay
+safe for concurrent use.
+
 ## TODOs
 
 * Ordered rapid tests that test the OrderedSet bits like the normal Set bits are tested.

--- a/locked.go
+++ b/locked.go
@@ -12,6 +12,13 @@ import (
 // Locked is a concurrency safe wrapper around a Set[M]. It uses a read-write lock to allow multiple readers to access
 // the set concurrently, but only one writer at a time. The set is not ordered and does not guarantee the order of
 // elements when iterating over them. It is safe for concurrent use.
+//
+// Locked delegates all of the package's optional optimization interfaces (Unioner,
+// Intersectioner, Differencer, SymmetricDifferencer, Equaler, Disjointer, Subsetter, Maxer, and
+// Minner) to the inner set under the read lock, so wrapping an optimizable set (e.g. a BitSet)
+// keeps its fast paths. A locked operand is unwrapped with a non-blocking lock attempt and the
+// delegation declines under contention, so these methods never deadlock; the declined call falls
+// back to the package-level generic path, which locks one set at a time.
 type Locked[M comparable] struct {
 	set Set[M]
 	sync.RWMutex
@@ -19,6 +26,16 @@ type Locked[M comparable] struct {
 
 var _ Set[int] = new(Locked[int])
 var _ driver.Valuer = new(Locked[int])
+var _ Unioner[int] = new(Locked[int])
+var _ Intersectioner[int] = new(Locked[int])
+var _ Differencer[int] = new(Locked[int])
+var _ SymmetricDifferencer[int] = new(Locked[int])
+var _ Equaler[int] = new(Locked[int])
+var _ Disjointer[int] = new(Locked[int])
+var _ Subsetter[int] = new(Locked[int])
+var _ Maxer[int] = new(Locked[int])
+var _ Minner[int] = new(Locked[int])
+var _ tryUnwrapper[int] = new(Locked[int])
 
 // NewLocked returns an empty *Locked[M] that is safe for concurrent use.
 func NewLocked[M comparable]() *Locked[M] {
@@ -137,6 +154,232 @@ func (s *Locked[M]) Pop() (M, bool) {
 	defer s.Unlock()
 
 	return s.set.Pop()
+}
+
+// tryUnwrapper is implemented by the locked wrappers so that one wrapper's optional-interface
+// delegation can reach another wrapper's inner set. The receiver's own lock is acquired normally,
+// but an operand wrapper's lock is only try-acquired: two goroutines running mirror-image
+// operations on the same pair of locked sets therefore can never deadlock — one of them declines
+// and takes the generic path, which locks one set at a time.
+type tryUnwrapper[M comparable] interface {
+	tryUnwrap() (Set[M], func(), bool)
+}
+
+// tryUnwrapOperand returns the set an inner optional-interface method should be handed for other:
+// a locked wrapper's inner set (read-locked, released via unlock) or other itself (unlock is a
+// no-op). ok is false when a wrapper's lock is contended or unusable; the caller must decline to
+// the generic path.
+func tryUnwrapOperand[M comparable](other Set[M]) (_ Set[M], unlock func(), ok bool) {
+	if w, ok := other.(tryUnwrapper[M]); ok {
+		return w.tryUnwrap()
+	}
+	return other, func() {}, true
+}
+
+//lint:ignore U1000 reached via the tryUnwrapper[M] type assertion in tryUnwrapOperand
+func (s *Locked[M]) tryUnwrap() (Set[M], func(), bool) {
+	if s == nil || !s.TryRLock() {
+		return nil, nil, false
+	}
+	if s.set == nil { // zero value: nothing to hand to an inner method
+		s.RUnlock()
+		return nil, nil, false
+	}
+	return s.set, s.RUnlock, true
+}
+
+// Union implements Unioner by delegating to the inner set's Unioner under the read lock,
+// unwrapping a locked other operand so two locked wrappers around optimizable sets still combine
+// on the fast path. On success the result is a new Locked wrapping the inner result. It declines
+// — sending the package-level Union down the generic path — when the inner set doesn't implement
+// Unioner or declines the operand, or when the operand wrapper's lock is contended (see
+// tryUnwrapper for why that cannot deadlock).
+func (s *Locked[M]) Union(other Set[M]) (Set[M], bool) {
+	if s == nil {
+		return nil, false
+	}
+	s.RLock()
+	defer s.RUnlock()
+	u, ok := s.set.(Unioner[M])
+	if !ok {
+		return nil, false
+	}
+	operand, unlock, ok := tryUnwrapOperand(other)
+	if !ok {
+		return nil, false
+	}
+	defer unlock()
+	c, ok := u.Union(operand)
+	if !ok {
+		return nil, false
+	}
+	return &Locked[M]{set: c}, true
+}
+
+// Intersection implements Intersectioner by delegating to the inner set's Intersectioner; see
+// Union for the delegation and locking rules shared by all of Locked's optional-interface
+// methods.
+func (s *Locked[M]) Intersection(other Set[M]) (Set[M], bool) {
+	if s == nil {
+		return nil, false
+	}
+	s.RLock()
+	defer s.RUnlock()
+	i, ok := s.set.(Intersectioner[M])
+	if !ok {
+		return nil, false
+	}
+	operand, unlock, ok := tryUnwrapOperand(other)
+	if !ok {
+		return nil, false
+	}
+	defer unlock()
+	c, ok := i.Intersection(operand)
+	if !ok {
+		return nil, false
+	}
+	return &Locked[M]{set: c}, true
+}
+
+// Difference implements Differencer by delegating to the inner set's Differencer; see Union for
+// the delegation and locking rules shared by all of Locked's optional-interface methods.
+func (s *Locked[M]) Difference(other Set[M]) (Set[M], bool) {
+	if s == nil {
+		return nil, false
+	}
+	s.RLock()
+	defer s.RUnlock()
+	d, ok := s.set.(Differencer[M])
+	if !ok {
+		return nil, false
+	}
+	operand, unlock, ok := tryUnwrapOperand(other)
+	if !ok {
+		return nil, false
+	}
+	defer unlock()
+	c, ok := d.Difference(operand)
+	if !ok {
+		return nil, false
+	}
+	return &Locked[M]{set: c}, true
+}
+
+// SymmetricDifference implements SymmetricDifferencer by delegating to the inner set's
+// SymmetricDifferencer; see Union for the delegation and locking rules shared by all of Locked's
+// optional-interface methods.
+func (s *Locked[M]) SymmetricDifference(other Set[M]) (Set[M], bool) {
+	if s == nil {
+		return nil, false
+	}
+	s.RLock()
+	defer s.RUnlock()
+	sd, ok := s.set.(SymmetricDifferencer[M])
+	if !ok {
+		return nil, false
+	}
+	operand, unlock, ok := tryUnwrapOperand(other)
+	if !ok {
+		return nil, false
+	}
+	defer unlock()
+	c, ok := sd.SymmetricDifference(operand)
+	if !ok {
+		return nil, false
+	}
+	return &Locked[M]{set: c}, true
+}
+
+// Equal implements Equaler by delegating to the inner set's Equaler; see Union for the delegation
+// and locking rules shared by all of Locked's optional-interface methods.
+func (s *Locked[M]) Equal(other Set[M]) (bool, bool) {
+	if s == nil {
+		return false, false
+	}
+	s.RLock()
+	defer s.RUnlock()
+	e, ok := s.set.(Equaler[M])
+	if !ok {
+		return false, false
+	}
+	operand, unlock, ok := tryUnwrapOperand(other)
+	if !ok {
+		return false, false
+	}
+	defer unlock()
+	return e.Equal(operand)
+}
+
+// Disjoint implements Disjointer by delegating to the inner set's Disjointer; see Union for the
+// delegation and locking rules shared by all of Locked's optional-interface methods.
+func (s *Locked[M]) Disjoint(other Set[M]) (bool, bool) {
+	if s == nil {
+		return false, false
+	}
+	s.RLock()
+	defer s.RUnlock()
+	d, ok := s.set.(Disjointer[M])
+	if !ok {
+		return false, false
+	}
+	operand, unlock, ok := tryUnwrapOperand(other)
+	if !ok {
+		return false, false
+	}
+	defer unlock()
+	return d.Disjoint(operand)
+}
+
+// Subset implements Subsetter by delegating to the inner set's Subsetter; see Union for the
+// delegation and locking rules shared by all of Locked's optional-interface methods.
+func (s *Locked[M]) Subset(other Set[M]) (bool, bool) {
+	if s == nil {
+		return false, false
+	}
+	s.RLock()
+	defer s.RUnlock()
+	sub, ok := s.set.(Subsetter[M])
+	if !ok {
+		return false, false
+	}
+	operand, unlock, ok := tryUnwrapOperand(other)
+	if !ok {
+		return false, false
+	}
+	defer unlock()
+	return sub.Subset(operand)
+}
+
+// Max implements Maxer by delegating to the inner set's Max under the read lock. Locked's element
+// type is only comparable, so the inner set is matched structurally rather than via Maxer[M]
+// (which requires cmp.Ordered); when Locked is instantiated with an ordered element type it
+// satisfies Maxer[M] and the package-level Max uses this automatically.
+func (s *Locked[M]) Max() (M, bool) {
+	var zero M
+	if s == nil {
+		return zero, false
+	}
+	s.RLock()
+	defer s.RUnlock()
+	if mx, ok := s.set.(interface{ Max() (M, bool) }); ok {
+		return mx.Max()
+	}
+	return zero, false
+}
+
+// Min implements Minner by delegating to the inner set's Min under the read lock; see Max for how
+// the inner set is matched.
+func (s *Locked[M]) Min() (M, bool) {
+	var zero M
+	if s == nil {
+		return zero, false
+	}
+	s.RLock()
+	defer s.RUnlock()
+	if mn, ok := s.set.(interface{ Min() (M, bool) }); ok {
+		return mn.Min()
+	}
+	return zero, false
 }
 
 // String returns a string representation of the set. It returns a string of the form LockedSet[T](<elements>).

--- a/locked_delegate_test.go
+++ b/locked_delegate_test.go
@@ -1,0 +1,213 @@
+package sets
+
+import (
+	"slices"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+// TestLockedDelegation differentially tests the locked wrappers' optional-interface delegation
+// against the generic Map-based results: every combination of wrapped/bare operands must agree
+// with the reference, algebra results must stay concurrency-safe wrappers, and inner sets that
+// cannot optimize must decline into the generic path.
+func TestLockedDelegation(t *testing.T) {
+	t.Parallel()
+
+	algebra := []struct {
+		name string
+		f    func(a, b Set[int]) Set[int]
+	}{
+		{"Union", Union[int]},
+		{"Intersection", Intersection[int]},
+		{"Difference", Difference[int]},
+		{"SymmetricDifference", SymmetricDifference[int]},
+	}
+	preds := []struct {
+		name string
+		f    func(a, b Set[int]) bool
+	}{
+		{"Equal", Equal[int]},
+		{"Disjoint", Disjoint[int]},
+		{"Subset", Subset[int]},
+		{"Superset", Superset[int]},
+	}
+
+	rapid.Check(t, func(t *rapid.T) {
+		av := rapid.SliceOfN(rapid.IntRange(-64, 64), 0, 24).Draw(t, "A")
+		var bv []int
+		switch rapid.SampledFrom([]string{"independent", "equal", "subset", "disjoint"}).Draw(t, "shape") {
+		case "independent":
+			bv = rapid.SliceOfN(rapid.IntRange(-64, 64), 0, 24).Draw(t, "B")
+		case "equal":
+			bv = slices.Clone(av)
+		case "subset":
+			for _, v := range av {
+				if rapid.Bool().Draw(t, "keep") {
+					bv = append(bv, v)
+				}
+			}
+		case "disjoint":
+			bv = rapid.SliceOfN(rapid.IntRange(65, 128), 0, 24).Draw(t, "B")
+		}
+		am, bm := NewWith(av...), NewWith(bv...)
+
+		// operand pairs covering wrapped×wrapped, wrapped×bare, cross-wrapper, and an inner type
+		// mismatch that must decline into the generic path
+		pairs := []struct {
+			name string
+			a, b Set[int]
+		}{
+			{"lockedBitSet×lockedBitSet", NewLockedWrapping(Set[int](NewBitSetWith(av...))), NewLockedWrapping(Set[int](NewBitSetWith(bv...)))},
+			{"lockedSorted×lockedSorted", NewLockedWrapping(Set[int](NewSortedSetWith(av...))), NewLockedWrapping(Set[int](NewSortedSetWith(bv...)))},
+			{"lockedBitSet×bareBitSet", NewLockedWrapping(Set[int](NewBitSetWith(av...))), NewBitSetWith(bv...)},
+			{"lockedBitSet×lockedOrderedBitSet", NewLockedWrapping(Set[int](NewBitSetWith(av...))), NewLockedOrderedWrapping(OrderedSet[int](NewBitSetWith(bv...)))},
+			{"lockedOrderedSorted×lockedOrderedSorted", NewLockedOrderedWrapping(OrderedSet[int](NewSortedSetWith(av...))), NewLockedOrderedWrapping(OrderedSet[int](NewSortedSetWith(bv...)))},
+			{"lockedBitSet×lockedSorted (declines)", NewLockedWrapping(Set[int](NewBitSetWith(av...))), NewLockedWrapping(Set[int](NewSortedSetWith(bv...)))},
+			{"lockedMap×lockedMap (declines)", NewLockedWrapping(Set[int](NewWith(av...))), NewLockedWrapping(Set[int](NewWith(bv...)))},
+		}
+
+		for _, pair := range pairs {
+			for _, op := range algebra {
+				want := op.f(am, bm)
+				got := op.f(pair.a, pair.b)
+				if !Equal(got, want) {
+					t.Fatalf("%s %s = %v, want %v (A=%v B=%v)", pair.name, op.name, Elements(got), Elements(want), av, bv)
+				}
+				if _, ok := got.(Locker); !ok {
+					t.Fatalf("%s %s returned %T, which is not concurrency-safe", pair.name, op.name, got)
+				}
+			}
+			for _, p := range preds {
+				want := p.f(am, bm)
+				if got := p.f(pair.a, pair.b); got != want {
+					t.Fatalf("%s %s = %v, want %v (A=%v B=%v)", pair.name, p.name, got, want, av, bv)
+				}
+			}
+			if len(av) > 0 {
+				if got, want := Max(pair.a), Max(am); got != want {
+					t.Fatalf("%s Max = %d, want %d", pair.name, got, want)
+				}
+				if got, want := Min(pair.a), Min(am); got != want {
+					t.Fatalf("%s Min = %d, want %d", pair.name, got, want)
+				}
+			}
+		}
+	})
+}
+
+// TestLockedDelegationResultTypes pins what the delegated fast paths produce: a new wrapper of
+// the receiver's kind around the inner result type, computed via the inner fast path.
+func TestLockedDelegationResultTypes(t *testing.T) {
+	t.Parallel()
+
+	a := NewLockedWrapping(Set[int](NewBitSetWith(1, 2)))
+	b := NewLockedWrapping(Set[int](NewBitSetWith(2, 3)))
+	got, ok := a.(*Locked[int]).Union(b)
+	if !ok {
+		t.Fatal("Locked(BitSet).Union(Locked(BitSet)) declined")
+	}
+	l, ok := got.(*Locked[int])
+	if !ok {
+		t.Fatalf("delegated Union returned %T, want *Locked[int]", got)
+	}
+	if _, ok := l.set.(*BitSet[int]); !ok {
+		t.Fatalf("delegated Union inner is %T, want *BitSet[int]", l.set)
+	}
+
+	oa := NewLockedOrderedWrapping(OrderedSet[int](NewSortedSetWith(1, 2)))
+	ogot, ok := oa.(*LockedOrdered[int]).Union(NewSortedSetWith(2, 3))
+	if !ok {
+		t.Fatal("LockedOrdered(SortedSet).Union(SortedSet) declined")
+	}
+	lo, ok := ogot.(*LockedOrdered[int])
+	if !ok {
+		t.Fatalf("delegated Union returned %T, want *LockedOrdered[int]", ogot)
+	}
+	if _, ok := lo.set.(*SortedSet[int]); !ok {
+		t.Fatalf("delegated Union inner is %T, want *SortedSet[int]", lo.set)
+	}
+
+	// method-level declines: inner set without the interface, and mismatched inner types
+	m := NewLockedWrapping(Set[int](NewWith(1)))
+	if _, ok := m.(*Locked[int]).Union(b); ok {
+		t.Fatal("Locked(Map).Union must decline")
+	}
+	if _, ok := a.(*Locked[int]).Union(NewLockedWrapping(Set[int](NewSortedSetWith(1)))); ok {
+		t.Fatal("Locked(BitSet).Union(Locked(SortedSet)) must decline")
+	}
+}
+
+// TestLockedDelegationContention pins the deadlock-avoidance rule: when the operand wrapper's
+// lock is write-held, delegation declines immediately instead of blocking.
+func TestLockedDelegationContention(t *testing.T) {
+	t.Parallel()
+
+	a := NewLockedWrapping(Set[int](NewBitSetWith(1, 2))).(*Locked[int])
+	b := NewLockedWrapping(Set[int](NewBitSetWith(2, 3))).(*Locked[int])
+
+	b.Lock()
+	if _, ok := a.Union(b); ok {
+		t.Fatal("Union with a write-locked operand must decline")
+	}
+	if _, ok := a.Equal(b); ok {
+		t.Fatal("Equal with a write-locked operand must decline")
+	}
+	if _, ok := a.Subset(b); ok {
+		t.Fatal("Subset with a write-locked operand must decline")
+	}
+	// the receiver's own lock is unaffected: bare operands still delegate
+	if _, ok := a.Union(NewBitSetWith(9)); !ok {
+		t.Fatal("Union with a bare operand declined during unrelated contention")
+	}
+	b.Unlock()
+
+	if _, ok := a.Union(b); !ok {
+		t.Fatal("Union declined after the contention was released")
+	}
+
+	// self-operand: the try-acquired second read lock on the same wrapper succeeds
+	if c, ok := a.Union(a); !ok || !Equal(c, a) {
+		t.Fatal("Union with the receiver itself as operand must delegate and equal the receiver")
+	}
+}
+
+// TestLockedDelegationNilAndZero pins nil/zero-value safety: typed-nil wrappers and zero-value
+// wrappers (nil inner set) decline both as receivers and as unwrapped operands.
+func TestLockedDelegationNilAndZero(t *testing.T) {
+	t.Parallel()
+
+	var nl *Locked[int]
+	var nlo *LockedOrdered[int]
+	if _, ok := nl.Union(NewWith(1)); ok {
+		t.Fatal("nil Locked.Union reported handled")
+	}
+	if _, ok := nl.Equal(NewWith(1)); ok {
+		t.Fatal("nil Locked.Equal reported handled")
+	}
+	if _, ok := nl.Max(); ok {
+		t.Fatal("nil Locked.Max reported ok")
+	}
+	if _, ok := nlo.Union(NewSortedSetWith(1)); ok {
+		t.Fatal("nil LockedOrdered.Union reported handled")
+	}
+	if _, ok := nlo.Max(); ok {
+		t.Fatal("nil LockedOrdered.Max reported ok")
+	}
+
+	var zl Locked[int]
+	if _, ok := zl.Union(NewBitSetWith(1)); ok {
+		t.Fatal("zero-value Locked.Union reported handled")
+	}
+	if _, ok := zl.Max(); ok {
+		t.Fatal("zero-value Locked.Max reported ok")
+	}
+	// zero-value wrappers as operands decline the unwrap, so the receiver declines too
+	a := NewLockedWrapping(Set[int](NewBitSetWith(1))).(*Locked[int])
+	if _, ok := a.Union(&zl); ok {
+		t.Fatal("Union with a zero-value locked operand must decline")
+	}
+	if _, ok := a.Union(nl); ok {
+		t.Fatal("Union with a typed-nil locked operand must decline")
+	}
+}

--- a/locked_ordered.go
+++ b/locked_ordered.go
@@ -11,6 +11,11 @@ import (
 )
 
 // LockedOrdered is a concurrency safe wrapper around an OrderedSet[M]. It uses a read-write lock to allow multiple readers.
+//
+// LockedOrdered delegates all of the package's optional optimization interfaces (Unioner,
+// Intersectioner, Differencer, SymmetricDifferencer, Equaler, Disjointer, Subsetter, Maxer, and
+// Minner) to the inner set under the read lock, exactly as Locked does — see Locked for the
+// locking rules that make the delegation deadlock-free.
 type LockedOrdered[M cmp.Ordered] struct {
 	set OrderedSet[M]
 	sync.RWMutex
@@ -18,6 +23,16 @@ type LockedOrdered[M cmp.Ordered] struct {
 
 var _ Set[int] = new(LockedOrdered[int])
 var _ driver.Valuer = new(LockedOrdered[int])
+var _ Unioner[int] = new(LockedOrdered[int])
+var _ Intersectioner[int] = new(LockedOrdered[int])
+var _ Differencer[int] = new(LockedOrdered[int])
+var _ SymmetricDifferencer[int] = new(LockedOrdered[int])
+var _ Equaler[int] = new(LockedOrdered[int])
+var _ Disjointer[int] = new(LockedOrdered[int])
+var _ Subsetter[int] = new(LockedOrdered[int])
+var _ Maxer[int] = new(LockedOrdered[int])
+var _ Minner[int] = new(LockedOrdered[int])
+var _ tryUnwrapper[int] = new(LockedOrdered[int])
 
 // NewLockedOrdered returns an empty *LockedOrdered[M] instance that is safe for concurrent use.
 func NewLockedOrdered[M cmp.Ordered]() *LockedOrdered[M] {
@@ -190,6 +205,208 @@ func (s *LockedOrdered[M]) Index(m M) int {
 	defer s.RUnlock()
 
 	return s.set.Index(m)
+}
+
+//lint:ignore U1000 reached via the tryUnwrapper[M] type assertion in tryUnwrapOperand
+func (s *LockedOrdered[M]) tryUnwrap() (Set[M], func(), bool) {
+	if s == nil || !s.TryRLock() {
+		return nil, nil, false
+	}
+	if s.set == nil { // zero value: nothing to hand to an inner method
+		s.RUnlock()
+		return nil, nil, false
+	}
+	return s.set, s.RUnlock, true
+}
+
+// delegated returns the result of an inner set-algebra delegation rewrapped in a new
+// LockedOrdered. It declines when the inner result is not an OrderedSet (a conforming inner
+// OrderedSet's algebra methods always produce one, so this is purely defensive).
+func (s *LockedOrdered[M]) delegated(c Set[M], ok bool) (Set[M], bool) {
+	if !ok {
+		return nil, false
+	}
+	co, ok := c.(OrderedSet[M])
+	if !ok {
+		return nil, false
+	}
+	return &LockedOrdered[M]{set: co}, true
+}
+
+// Union implements Unioner by delegating to the inner set's Unioner under the read lock,
+// unwrapping a locked other operand so two locked wrappers around optimizable sets still combine
+// on the fast path. On success the result is a new LockedOrdered wrapping the inner result. It
+// declines — sending the package-level Union down the generic path — when the inner set doesn't
+// implement Unioner or declines the operand, or when the operand wrapper's lock is contended (see
+// tryUnwrapper for why that cannot deadlock).
+func (s *LockedOrdered[M]) Union(other Set[M]) (Set[M], bool) {
+	if s == nil {
+		return nil, false
+	}
+	s.RLock()
+	defer s.RUnlock()
+	u, ok := s.set.(Unioner[M])
+	if !ok {
+		return nil, false
+	}
+	operand, unlock, ok := tryUnwrapOperand(other)
+	if !ok {
+		return nil, false
+	}
+	defer unlock()
+	return s.delegated(u.Union(operand))
+}
+
+// Intersection implements Intersectioner by delegating to the inner set's Intersectioner; see
+// Union for the delegation and locking rules shared by all of LockedOrdered's optional-interface
+// methods.
+func (s *LockedOrdered[M]) Intersection(other Set[M]) (Set[M], bool) {
+	if s == nil {
+		return nil, false
+	}
+	s.RLock()
+	defer s.RUnlock()
+	i, ok := s.set.(Intersectioner[M])
+	if !ok {
+		return nil, false
+	}
+	operand, unlock, ok := tryUnwrapOperand(other)
+	if !ok {
+		return nil, false
+	}
+	defer unlock()
+	return s.delegated(i.Intersection(operand))
+}
+
+// Difference implements Differencer by delegating to the inner set's Differencer; see Union for
+// the delegation and locking rules shared by all of LockedOrdered's optional-interface methods.
+func (s *LockedOrdered[M]) Difference(other Set[M]) (Set[M], bool) {
+	if s == nil {
+		return nil, false
+	}
+	s.RLock()
+	defer s.RUnlock()
+	d, ok := s.set.(Differencer[M])
+	if !ok {
+		return nil, false
+	}
+	operand, unlock, ok := tryUnwrapOperand(other)
+	if !ok {
+		return nil, false
+	}
+	defer unlock()
+	return s.delegated(d.Difference(operand))
+}
+
+// SymmetricDifference implements SymmetricDifferencer by delegating to the inner set's
+// SymmetricDifferencer; see Union for the delegation and locking rules shared by all of
+// LockedOrdered's optional-interface methods.
+func (s *LockedOrdered[M]) SymmetricDifference(other Set[M]) (Set[M], bool) {
+	if s == nil {
+		return nil, false
+	}
+	s.RLock()
+	defer s.RUnlock()
+	sd, ok := s.set.(SymmetricDifferencer[M])
+	if !ok {
+		return nil, false
+	}
+	operand, unlock, ok := tryUnwrapOperand(other)
+	if !ok {
+		return nil, false
+	}
+	defer unlock()
+	return s.delegated(sd.SymmetricDifference(operand))
+}
+
+// Equal implements Equaler by delegating to the inner set's Equaler; see Union for the delegation
+// and locking rules shared by all of LockedOrdered's optional-interface methods.
+func (s *LockedOrdered[M]) Equal(other Set[M]) (bool, bool) {
+	if s == nil {
+		return false, false
+	}
+	s.RLock()
+	defer s.RUnlock()
+	e, ok := s.set.(Equaler[M])
+	if !ok {
+		return false, false
+	}
+	operand, unlock, ok := tryUnwrapOperand(other)
+	if !ok {
+		return false, false
+	}
+	defer unlock()
+	return e.Equal(operand)
+}
+
+// Disjoint implements Disjointer by delegating to the inner set's Disjointer; see Union for the
+// delegation and locking rules shared by all of LockedOrdered's optional-interface methods.
+func (s *LockedOrdered[M]) Disjoint(other Set[M]) (bool, bool) {
+	if s == nil {
+		return false, false
+	}
+	s.RLock()
+	defer s.RUnlock()
+	d, ok := s.set.(Disjointer[M])
+	if !ok {
+		return false, false
+	}
+	operand, unlock, ok := tryUnwrapOperand(other)
+	if !ok {
+		return false, false
+	}
+	defer unlock()
+	return d.Disjoint(operand)
+}
+
+// Subset implements Subsetter by delegating to the inner set's Subsetter; see Union for the
+// delegation and locking rules shared by all of LockedOrdered's optional-interface methods.
+func (s *LockedOrdered[M]) Subset(other Set[M]) (bool, bool) {
+	if s == nil {
+		return false, false
+	}
+	s.RLock()
+	defer s.RUnlock()
+	sub, ok := s.set.(Subsetter[M])
+	if !ok {
+		return false, false
+	}
+	operand, unlock, ok := tryUnwrapOperand(other)
+	if !ok {
+		return false, false
+	}
+	defer unlock()
+	return sub.Subset(operand)
+}
+
+// Max implements Maxer by delegating to the inner set's Maxer under the read lock. It declines
+// when the inner set doesn't implement Maxer or cannot answer, sending the package-level Max down
+// the generic path.
+func (s *LockedOrdered[M]) Max() (M, bool) {
+	var zero M
+	if s == nil {
+		return zero, false
+	}
+	s.RLock()
+	defer s.RUnlock()
+	if mx, ok := s.set.(Maxer[M]); ok {
+		return mx.Max()
+	}
+	return zero, false
+}
+
+// Min implements Minner by delegating to the inner set's Minner under the read lock; see Max.
+func (s *LockedOrdered[M]) Min() (M, bool) {
+	var zero M
+	if s == nil {
+		return zero, false
+	}
+	s.RLock()
+	defer s.RUnlock()
+	if mn, ok := s.set.(Minner[M]); ok {
+		return mn.Min()
+	}
+	return zero, false
 }
 
 // String returns a string representation of the set. It returns a string of the form LockedOrderedSet[T](<elements>).

--- a/set.go
+++ b/set.go
@@ -88,7 +88,10 @@ func RemoveSeq[K comparable](s Set[K], seq iter.Seq[K]) int {
 // implements it. The Intersectioner, Differencer, and SymmetricDifferencer interfaces work the
 // same way for the other set-algebra functions; implement whichever subset you can optimize.
 // BitSet implements all four with word-wise operations; SortedSet implements all four with a
-// single linear merge of the two sorted backing slices.
+// single linear merge of the two sorted backing slices. The locked wrappers (Locked and
+// LockedOrdered) delegate every optional optimization interface — these four, the predicates, and
+// Maxer/Minner — to their inner set under the read lock, so wrapping an optimizable set keeps its
+// fast paths.
 //
 // The boolean return is deliberate: implementing one of these interfaces opts a type into an
 // operation, and the boolean additionally lets each call decline a specific operand — typically

--- a/stresstest/locked_delegate_stress_test.go
+++ b/stresstest/locked_delegate_stress_test.go
@@ -1,0 +1,70 @@
+package stresstest
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/freeformz/sets"
+)
+
+// TestLockedDelegationConcurrency hammers the locked wrappers' optional-interface delegation
+// from both operand orders at once — the classic two-lock deadlock shape — while writers mutate
+// both sets. The delegation must stay deadlock-free (operand locks are only try-acquired; under
+// contention it declines into the generic one-lock-at-a-time path) and race-free under -race.
+// Contents race with the writers, so only type invariants are asserted; the real assertions are
+// that the test terminates and the race detector stays quiet.
+func TestLockedDelegationConcurrency(t *testing.T) {
+	t.Parallel()
+
+	iters := 2000
+	if testing.Short() {
+		iters = 200
+	}
+
+	a := sets.NewLockedWrapping(sets.Set[int](sets.NewBitSetWith(1, 2, 3)))
+	b := sets.NewLockedWrapping(sets.Set[int](sets.NewBitSetWith(3, 4, 5)))
+
+	var wg sync.WaitGroup
+	for g := range 4 {
+		wg.Go(func() {
+			x, y := a, b
+			if g%2 == 1 { // half the goroutines run the mirror-image operand order
+				x, y = y, x
+			}
+			for i := range iters {
+				switch i % 5 {
+				case 0:
+					if u := sets.Union(x, y); u == nil {
+						t.Error("Union returned nil")
+						return
+					}
+				case 1:
+					if d := sets.Difference(x, y); d == nil {
+						t.Error("Difference returned nil")
+						return
+					}
+				case 2:
+					sets.Equal(x, y)
+				case 3:
+					sets.Subset(x, y)
+				case 4:
+					sets.Disjoint(x, y)
+				}
+			}
+		})
+	}
+	for w := range 2 {
+		wg.Go(func() {
+			for i := range iters {
+				if w == 0 {
+					a.Add(i % 64)
+					b.Remove(i % 64)
+				} else {
+					b.Add(i % 64)
+					a.Remove(i % 64)
+				}
+			}
+		})
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

Third item from the optional-interface survey (follow-up to #42/#43): wrapping a set in `Locked` or `LockedOrdered` no longer silently discards its fast paths. Both wrappers now implement all nine optional interfaces — `Unioner`/`Intersectioner`/`Differencer`/`SymmetricDifferencer`, `Equaler`/`Disjointer`/`Subsetter`, and `Maxer`/`Minner` — by delegating to the inner set under the read lock, declining to the generic path when the inner set doesn't implement or declines the hook.

### Deadlock safety

Delegation may need **two** locks (receiver + a locked operand), and two goroutines running mirror-image operations on the same pair is the classic deadlock shape. The rule: the receiver's own lock is acquired normally, but a locked operand is unwrapped with a **non-blocking `TryRLock`** — under contention the delegation declines, and the package-level function falls back to the generic path, which locks one set at a time. The declining-boolean contract absorbs contention the same way it absorbs type mismatches: worst outcome is generic speed, never a wrong result or a deadlock. A `-race` stress test runs both operand orders concurrently against writers to pin this.

### Notes

- Delegated set-algebra results come back wrapped (`Locked`/`LockedOrdered`), staying concurrency-safe and keeping the package functions' same-underlying-type-as-a contract
- `Locked`'s element type is only `comparable`, so its `Max`/`Min` match the inner set structurally (`interface{ Max() (M, bool) }`); instantiated with an ordered element type, `Locked` satisfies `Maxer`/`Minner` (compile-time asserted)
- Typed-nil and zero-value (nil inner) wrappers decline as both receivers and operands — the nil-safety class from #42, handled up front
- Cross-wrapper delegation works: `Locked(BitSet)` × `LockedOrdered(BitSet)` still hits the word-wise fast path

## Testing

- `TestLockedDelegation`: rapid differential test against Map-based generic results across seven operand pairings — wrapped×wrapped, wrapped×bare, cross-wrapper, and declining combinations (mismatched inner types, non-optimizable `Map` inner) — for all four algebra ops, all four predicates, and `Max`/`Min`; algebra results asserted to be `Locker`s
- `TestLockedDelegationResultTypes`: pins the wrapper/inner types of delegated results and method-level declines
- `TestLockedDelegationContention`: deterministic decline while the operand is write-locked (and recovery after unlock; self-operand delegation)
- `TestLockedDelegationNilAndZero`: typed-nil and zero-value pins
- `stresstest.TestLockedDelegationConcurrency`: 4 readers in mirror-image operand orders + 2 writers under `-race` — terminates (no deadlock) and race-clean
- `go vet`, `staticcheck`, and `go test -race ./...` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLrWSEKLMPuf1kq1KDCoxs